### PR TITLE
Temporary fix to stop audio bugs when clicking on track title

### DIFF
--- a/app/views/tracks/_track.html.erb
+++ b/app/views/tracks/_track.html.erb
@@ -11,7 +11,8 @@
       <% end %>
     </div>
     <div class="flex flex-col justify-between items-start">
-      <%= link_to "#{track.title}", track_path(track), class: "text-sm cursor-pointer hover:underline" %>
+      <%= link_to "#{track.title}", track_path(track), class: "text-sm cursor-pointer hover:underline",
+        data: { action: "click->audio-player#stopPropagation" } %>
       <div class="flex justify-start items-center gap-1 text-secondary-txt text-[0.6rem]">
         <span><%= "#{track.bpm} BPM" %></span>
         <span>·</span>


### PR DESCRIPTION
## Proposed Changes
As discovered in this issue: #81, this is a temporary fix. What it does is it stops event bubbling but what happens is when navigating to a different link done this way the track closes, which not ideal.

## Type of Change
- [ ] 🚨 *Breaking change* (fix or feature that would cause existing functionality to change)
- [ ] ✨ *New feature* (non-breaking change that adds functionality)
- [x] 🐛 *Bug fix* (non-breaking change that fixes an issue)
- [ ] 🎨 *User interface change* (change to user interface; provide screenshots)
- [ ] ♻️ *Refactoring* (internal change to codebase, without changing functionality)
- [ ] 🚦 *Test update* (change that adds or modifies tests)
- [ ] 📦 *Dependency update* (change that updates a dependency)
- [ ] 🔧 *Internal* (change that affects developers or continuous integration)


## Checklist

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [ ] I have added tests for my changes, if applicable.
- [ ] I have updated the project documentation, if applicable.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.