### PR TITLE
Infinite scroll user tracks page

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -44,3 +44,13 @@
     opacity: 1;
   }
 }
+
+.loader {
+  animation: loadSpin1 1s infinite;
+}
+
+@keyframes loadSpin1 {
+  to{
+    transform: rotate(.5turn)
+  }
+}

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -163,6 +163,10 @@
     @apply text-[0.6rem] text-secondary-txt;
   }
 
+  .loader {
+    @apply w-8 aspect-square rounded-full border-4 border-secondary-txt border-y-transparent;
+  }
+
   /* Authentication */
   .auth-form {
     @apply

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -1,9 +1,8 @@
 class TracksController < ApplicationController
   def index
-    # TODO pagination
     base_scope = Track.where(is_public: true)
     @q = base_scope.ransack(params[:q], auth_object: current_user)
-    queried_tracks = @q.result.includes(:tags)
+    queried_tracks = @q.result.includes(:tags).order(created_at: :desc)
     @pagy, @tracks = pagy_keyset(queried_tracks, limit: 20)
 
     if turbo_or_xhr_request?

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -2,18 +2,7 @@ class TracksController < ApplicationController
   def index
     base_scope = Track.where(is_public: true)
     @q = base_scope.ransack(params[:q], auth_object: current_user)
-
-    # need ordering for pagy_keyset, but there are dynamic order queries
-    sorts = if @q.sorts.any?
-      @q.sorts.map do |s|
-        direction = s.dir.downcase.to_sym
-        [s.name.to_sym, direction]
-      end.to_h
-    else
-      { created_at: :desc, id: :desc }
-    end
-
-    queried_tracks = @q.result.includes(:tags).reorder(sorts)
+    queried_tracks = @q.result.includes(:tags).order(created_at: :desc)
     @pagy, @tracks = pagy_keyset(queried_tracks, limit: 20)
 
     respond_to do |format|

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -16,8 +16,11 @@ class TracksController < ApplicationController
     queried_tracks = @q.result.includes(:tags).reorder(sorts)
     @pagy, @tracks = pagy_keyset(queried_tracks, limit: 20)
 
-    if turbo_or_xhr_request?
-      render partial: "tracks/track_list", locals: { tracks: @tracks }
+    respond_to do |format|
+      format.html
+      format.turbo_stream do
+        render :index, formats: :turbo_stream
+      end
     end
   end
 

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -2,7 +2,18 @@ class TracksController < ApplicationController
   def index
     base_scope = Track.where(is_public: true)
     @q = base_scope.ransack(params[:q], auth_object: current_user)
-    queried_tracks = @q.result.includes(:tags).order(created_at: :desc)
+
+    # need ordering for pagy_keyset, but there are dynamic order queries
+    sorts = if @q.sorts.any?
+      @q.sorts.map do |s|
+        direction = s.dir.downcase.to_sym
+        [s.name.to_sym, direction]
+      end.to_h
+    else
+      { created_at: :desc, id: :desc }
+    end
+
+    queried_tracks = @q.result.includes(:tags).reorder(sorts)
     @pagy, @tracks = pagy_keyset(queried_tracks, limit: 20)
 
     if turbo_or_xhr_request?

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -3,7 +3,8 @@ class TracksController < ApplicationController
     # TODO pagination
     base_scope = Track.where(is_public: true)
     @q = base_scope.ransack(params[:q], auth_object: current_user)
-    @tracks = @q.result.includes(:tags)
+    queried_tracks = @q.result.includes(:tags)
+    @pagy, @tracks = pagy_keyset(queried_tracks, limit: 20)
 
     if turbo_or_xhr_request?
       render partial: "tracks/track_list", locals: { tracks: @tracks }

--- a/app/views/shared/_load_more.html.erb
+++ b/app/views/shared/_load_more.html.erb
@@ -1,0 +1,9 @@
+<% if pagy&.next %>
+  <%= turbo_frame_tag "load-more", loading: :lazy, src: { pagy: pagy.next, format: turbo_stream } do  %>
+    <%= turbo_frame_tag "load-more" do %>
+      <div class="flex justify-center items-center w-full my-8">
+        <div class="loader"></div>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/shared/_load_more.html.erb
+++ b/app/views/shared/_load_more.html.erb
@@ -1,9 +1,7 @@
 <% if pagy&.next %>
-  <%= turbo_frame_tag "load-more", loading: :lazy, src: { pagy: pagy.next, format: turbo_stream } do  %>
-    <%= turbo_frame_tag "load-more" do %>
-      <div class="flex justify-center items-center w-full my-8">
-        <div class="loader"></div>
-      </div>
-    <% end %>
+  <%= turbo_frame_tag "load-more", loading: :lazy, src: { page: pagy.next, format: :turbo_stream } do  %>
+    <div class="flex justify-center items-center w-full my-8">
+      <div class="loader"></div>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/tracks/_filter.html.erb
+++ b/app/views/tracks/_filter.html.erb
@@ -44,7 +44,7 @@
       {
         field: t("track.order_by"),
         dropdown_id: "sort-dropdown",
-        for_admin: true,
+        for_admin: false,
       },
       {
         field: t("track.visibility"),

--- a/app/views/tracks/_filter.html.erb
+++ b/app/views/tracks/_filter.html.erb
@@ -44,7 +44,7 @@
       {
         field: t("track.order_by"),
         dropdown_id: "sort-dropdown",
-        for_admin: false,
+        for_admin: true,
       },
       {
         field: t("track.visibility"),
@@ -52,7 +52,8 @@
         for_admin: true,
       },
     ].each do |data| %>
-      <% next if data[:for_admin] && !current_user&.admin? %>
+      <%# Temp solution, shuold refactor these into reuseable components %>
+      <% next if (data[:for_admin] && !current_user&.admin?) || (data[:dropdown_id] == "sort-dropdown" && request.path == tracks_path) %>
       <button id="<%= "#{data[:dropdown_id]}-btn" %>" data-dropdown-toggle="<%= data[:dropdown_id] %>" type="button"
         class="flex justify-center items-center gap-1 bg-none cursor-pointer focus:ring-0 focus:border-none">
         <%= data[:field] %>
@@ -137,18 +138,20 @@
   <% end %>
 
   <%# Sort dropdown %>
-  <div id="sort-dropdown" class="z-10 p-3 hidden bg-background dark:bg-secondary-bg rounded-lg shadow-sm">
-    <span class="flex flex-col justify-start items-start gap-2 text-[0.7rem]">
-      <% [
-        { field: :title, title: t("track.title") },
-        { field: :bpm, title: "BPM" },
-        { field: :created_at, title: t("track.created_at") },
-        { field: :updated, title: t("track.updated_at") },
-      ].each do |option| %>
-        <%= sort_link(@q, option[:field], option[:title]) %>
-      <% end %>
-    </span>
-  </div>
+  <% unless request.path == tracks_path %>
+    <div id="sort-dropdown" class="z-10 p-3 hidden bg-background dark:bg-secondary-bg rounded-lg shadow-sm">
+      <span class="flex flex-col justify-start items-start gap-2 text-[0.7rem]">
+        <% [
+          { field: :title, title: t("track.title") },
+          { field: :bpm, title: "BPM" },
+          { field: :created_at, title: t("track.created_at") },
+          { field: :updated, title: t("track.updated_at") },
+        ].each do |option| %>
+          <%= sort_link(@q, option[:field], option[:title]) %>
+        <% end %>
+      </span>
+    </div>
+  <% end %>
 
   <div class="flex justify-start items-stretch gap-2">
     <% [

--- a/app/views/tracks/_track.html.erb
+++ b/app/views/tracks/_track.html.erb
@@ -1,8 +1,10 @@
+<% index ||= nil %>
+
 <div id="<%= dom_id track %>" class="flex justify-between items-stretch w-full sm:w-auto rounded p-2 hover:bg-hover cursor-pointer"
   data-track-id="<%= track.id %>" data-action="click->audio-player#play"
 >
   <div class="flex justify-start itmes-center gap-4 truncate min-w-30">
-    <div class="flex justify-center items-center text-xs text-secondary-txt"><%= index %></div>
+    <div class="flex justify-center items-center text-xs text-secondary-txt"><%= index&.present? ? index : "•" %></div>
     <div class="flex justify-center items-center rounded w-8 h-8 min-w-8 min-h-8 bg-secondary-bg">
       <% if track.cover_photo.attached? %>
         <img src="<%= url_for(track.cover_photo) %>" class="flex justify-center items-center w-full h-full rounded">

--- a/app/views/tracks/_track_list.html.erb
+++ b/app/views/tracks/_track_list.html.erb
@@ -1,9 +1,7 @@
-<turbo-frame id="track-list">
-  <% if tracks.any? %>
-    <% tracks.each_with_index do |t, i| %>
-      <%= render "tracks/track", track: t, index: i + 1 %>
-    <% end %>
-  <% else %>
-    <p class="text-center my-10">No tracks found.</p>
+<% if tracks.any? %>
+  <% tracks.each_with_index do |t, i| %>
+    <%= render "tracks/track", track: t, index: i + 1 %>
   <% end %>
-</turbo-frame>
+<% else %>
+  <p class="text-center my-10"><%= t("track.no_tracks_found") %></p>
+<% end %>

--- a/app/views/tracks/_track_list.html.erb
+++ b/app/views/tracks/_track_list.html.erb
@@ -1,6 +1,6 @@
 <% if tracks.any? %>
   <% tracks.each_with_index do |t, i| %>
-    <%= render "tracks/track", track: t, index: i + 1 %>
+    <%= render "tracks/track", track: t %>
   <% end %>
 <% else %>
   <p class="text-center my-10"><%= t("track.no_tracks_found") %></p>

--- a/app/views/tracks/index.html.erb
+++ b/app/views/tracks/index.html.erb
@@ -6,9 +6,9 @@
   <%= render "tracks/filter", url: tracks_path %>
 
   <div id="tracks" class="min-w-full mt-8">
-    <turbo-frame id="track-list">
+    <%= turbo_frame_tag "track-list", target: "_top" do %>
       <%= render partial: "tracks/track_list", locals: { tracks: @tracks } %>
-    </turbo-frame>
+    <% end %>
 
     <%= render "shared/load_more", pagy: @pagy %>
   </div>

--- a/app/views/tracks/index.html.erb
+++ b/app/views/tracks/index.html.erb
@@ -9,5 +9,7 @@
     <turbo-frame id="track-list">
       <%= render partial: "tracks/track_list", locals: { tracks: @tracks } %>
     </turbo-frame>
+
+    <%= render "shared/load_more", pagy: @pagy %>
   </div>
 </div>

--- a/app/views/tracks/index.turbo_stream.erb
+++ b/app/views/tracks/index.turbo_stream.erb
@@ -6,6 +6,4 @@
   <%= turbo_stream.replace "load-more" do %>
     <%= render "shared/load_more", pagy: @pagy %>
   <% end %>
-<% else %>
-  <%= turbo_stream.remove "load-more" %>
 <% end %>

--- a/app/views/tracks/index.turbo_stream.erb
+++ b/app/views/tracks/index.turbo_stream.erb
@@ -1,0 +1,11 @@
+<% if @tracks.any? %>
+  <%= turbo_stream.append "track-list" do %>
+    <%= render partial: "tracks/track_list", locals: { tracks: @tracks } %>
+  <% end %>
+
+  <%= turbo_stream.replace "load-more" do %>
+    <%= render "shared/load_more", pagy: @pagy %>
+  <% end %>
+<% else %>
+  <%= turbo_stream.remove "load-more" %>
+<% end %>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -81,7 +81,7 @@ Pagy::DEFAULT[:count_args]  = []                    # example for non AR ORMs
 
 # Keyset extra: Paginate with the Pagy keyset pagination technique
 # See https://ddnexus.github.io/pagy/docs/extras/keyset
-# require 'pagy/extras/keyset'
+require 'pagy/extras/keyset'
 
 # Meilisearch extra: Paginate `Meilisearch` result objects
 # See https://ddnexus.github.io/pagy/docs/extras/meilisearch

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -81,7 +81,7 @@ Pagy::DEFAULT[:count_args]  = []                    # example for non AR ORMs
 
 # Keyset extra: Paginate with the Pagy keyset pagination technique
 # See https://ddnexus.github.io/pagy/docs/extras/keyset
-require 'pagy/extras/keyset'
+require "pagy/extras/keyset"
 
 # Meilisearch extra: Paginate `Meilisearch` result objects
 # See https://ddnexus.github.io/pagy/docs/extras/meilisearch

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -87,6 +87,7 @@ en:
     see_track: "See track"
     heart_track: "Like track"
     save_track: "Save track"
+    no_tracks_found: "No tracks found"
     filter_placeholder: "Enter track names, description or tags"
     genres: "Genres"
     keys: "Keys"


### PR DESCRIPTION
## Proposed Changes
Allow infinite scrolling for users to browse tracks easily using `pagy`. Sorting functionality is removed for that page as it messes up infinite scroll pagination queries.

## Type of Change
- [x] 🚨 *Breaking change* (fix or feature that would cause existing functionality to change)
- [x] ✨ *New feature* (non-breaking change that adds functionality)
- [ ] 🐛 *Bug fix* (non-breaking change that fixes an issue)
- [x] 🎨 *User interface change* (change to user interface; provide screenshots)
- [ ] ♻️ *Refactoring* (internal change to codebase, without changing functionality)
- [ ] 🚦 *Test update* (change that adds or modifies tests)
- [ ] 📦 *Dependency update* (change that updates a dependency)
- [ ] 🔧 *Internal* (change that affects developers or continuous integration)


## Checklist

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [ ] I have added tests for my changes, if applicable.
- [ ] I have updated the project documentation, if applicable.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.