### PR TITLE
Fix infinite scroll render bug

### DIFF
--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -4,13 +4,6 @@ class TracksController < ApplicationController
     @q = base_scope.ransack(params[:q], auth_object: current_user)
     queried_tracks = @q.result.includes(:tags).order(created_at: :desc)
     @pagy, @tracks = pagy_keyset(queried_tracks, limit: 20)
-
-    respond_to do |format|
-      format.html
-      format.turbo_stream do
-        render :index, formats: :turbo_stream
-      end
-    end
   end
 
   def show

--- a/app/views/tracks/_filter.html.erb
+++ b/app/views/tracks/_filter.html.erb
@@ -4,8 +4,8 @@
     data: {
       controller: "track-filter",
       track_filter_target: "form",
-      turbo_frame: "track-list",
-      turbo_action: "replace",
+      # turbo_frame: "track-list",
+      # turbo_action: "replace",
     }
   } do |f| %>
   <div class="flex justify-start items-stretch flex-nowrap gap-3 w-full mb-4">

--- a/app/views/tracks/_track_list.html.erb
+++ b/app/views/tracks/_track_list.html.erb
@@ -1,5 +1,5 @@
 <% if tracks.any? %>
-  <% tracks.each_with_index do |t, i| %>
+  <% tracks.each do |t| %>
     <%= render "tracks/track", track: t %>
   <% end %>
 <% else %>


### PR DESCRIPTION
## Proposed Changes
There's a bug in track infinite scroll where when you filter tracks, it will render the filter result but append the original track list to the result due to filter is submitted through a turbo frame request and turbo stream renders all of the previous results. This bug is fixed by re-rendering the page rather than replacing `track-list` turbo frame.

## Type of Change
- [ ] 🚨 *Breaking change* (fix or feature that would cause existing functionality to change)
- [ ] ✨ *New feature* (non-breaking change that adds functionality)
- [ ] 🐛 *Bug fix* (non-breaking change that fixes an issue)
- [ ] 🎨 *User interface change* (change to user interface; provide screenshots)
- [ ] ♻️ *Refactoring* (internal change to codebase, without changing functionality)
- [ ] 🚦 *Test update* (change that adds or modifies tests)
- [ ] 📦 *Dependency update* (change that updates a dependency)
- [ ] 🔧 *Internal* (change that affects developers or continuous integration)


## Checklist

- [ ] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [ ] I have added tests for my changes, if applicable.
- [ ] I have updated the project documentation, if applicable.
- [ ] I have verified that the CI tests have passed.
- [ ] I have reviewed the test coverage changes reported by Coveralls.