### PR TITLE
Nullify Track and User model with Heart and Play associations

### DIFF
--- a/app/javascript/controllers/audio_player_controller.js
+++ b/app/javascript/controllers/audio_player_controller.js
@@ -210,7 +210,7 @@ export default class extends Controller {
       // TODO Toast if track audio src is empty
     });
 
-    if (!this.currentTrackId) return;
+    // if (!this.currentTrackId) return;
     fetch(`/tracks/${this.currentTrackId}/play`, {
       method: "POST",
       headers: {

--- a/app/javascript/controllers/audio_player_controller.js
+++ b/app/javascript/controllers/audio_player_controller.js
@@ -210,7 +210,7 @@ export default class extends Controller {
       // TODO Toast if track audio src is empty
     });
 
-    // if (!this.currentTrackId) return;
+    if (!this.currentTrackId) return;
     fetch(`/tracks/${this.currentTrackId}/play`, {
       method: "POST",
       headers: {

--- a/app/models/track/heart.rb
+++ b/app/models/track/heart.rb
@@ -3,6 +3,6 @@ class Track::Heart < ApplicationRecord
 
   validates :user_id, uniqueness: { scope: :track_id }
 
-  belongs_to :user
-  belongs_to :track
+  belongs_to :user, optional: true
+  belongs_to :track, optional: true
 end

--- a/app/models/track/play.rb
+++ b/app/models/track/play.rb
@@ -2,5 +2,5 @@ class Track::Play < ApplicationRecord
   self.table_name = "track_plays"
 
   belongs_to :user, optional: true
-  belongs_to :track
+  belongs_to :track, optional: true
 end

--- a/app/views/admin/tracks/_track_list.html.erb
+++ b/app/views/admin/tracks/_track_list.html.erb
@@ -1,58 +1,60 @@
-<turbo-frame id="track-list">
-  <% if tracks.any? %>
-    <div class="grid [grid-template-columns:repeat(auto-fit,minmax(10rem,1fr))] gap-x-2 gap-y-8">
-      <% @tracks.each do |track| %>
-        <%# the width of the card is width of image + 2 in tailwind %>
-        <div class="flex flex-col justify-start items-stretch bg-background dark:bg-secondary-bg w-42 h-fit rounded p-1">
-          <%= render "shared/cover_photo_player", track: track, img_size: "w-40" %>
+<% if tracks.any? %>
+  <div class="grid [grid-template-columns:repeat(auto-fit,minmax(10rem,1fr))] gap-x-2 gap-y-8">
+    <% @tracks.each do |track| %>
+      <%# the width of the card is width of image + 2 in tailwind %>
+      <div class="flex flex-col justify-start items-stretch bg-background dark:bg-secondary-bg w-42 h-fit rounded p-1">
+        <%= render "shared/cover_photo_player", track: track, img_size: "w-40" %>
 
-          <div class="flex flex-col justify-start items-start gap-0.5 px-3 text-[0.6rem] mt-2 w-full">
-            <div class="flex justify-start items-stretch text-xs overflow-x-auto whitespace-nowrap w-full max-w-full">
-              <p class="truncate mb-2"><%= track.title %></p>
-              <p class="mx-1">·</p>
-              <p class="<%= track.is_public? ? "text-success" : "text-error" %>"><%= track.is_public? ? "Public" : "Private" %></p>
-            </div>
-            <%= render "tracks/track_data", track: track, icon_size: "3" %>
+        <div class="flex flex-col justify-start items-start gap-0.5 px-3 text-[0.6rem] mt-2 w-full">
+          <div class="flex justify-start items-stretch text-xs overflow-x-auto whitespace-nowrap w-full max-w-full">
+            <p class="truncate mb-2"><%= track.title %></p>
+            <p class="mx-1">·</p>
+            <p class="<%= track.is_public? ? "text-success" : "text-error" %>"><%= track.is_public? ? "Public" : "Private" %></p>
           </div>
+          <%= render "tracks/track_data", track: track, icon_size: "3" %>
+        </div>
 
-          <div class="flex justify-between items-center text-[0.6rem] px-1 mt-4">
-            <div class="<%= track_file_upload_indicator_styles(track.tagged_mp3) %>">Tagged</div>
-            <div class="<%= track_file_upload_indicator_styles(track.untagged_mp3) %>">MP3</div>
-            <div class="<%= track_file_upload_indicator_styles(track.untagged_wav) %>">WAV</div>
-            <div class="<%= track_file_upload_indicator_styles(track.track_stems) %>">ZIP</div>
-          </div>
+        <div class="flex justify-between items-center text-[0.6rem] px-1 mt-4">
+          <div class="<%= track_file_upload_indicator_styles(track.tagged_mp3) %>">Tagged</div>
+          <div class="<%= track_file_upload_indicator_styles(track.untagged_mp3) %>">MP3</div>
+          <div class="<%= track_file_upload_indicator_styles(track.untagged_wav) %>">WAV</div>
+          <div class="<%= track_file_upload_indicator_styles(track.track_stems) %>">ZIP</div>
+        </div>
 
-          <div class="flex justify-end items-center p-2 mt-1">
-            <button data-dropdown-toggle="<%= track_more_dropdown_id(track) %>" data-dropdown-placement="bottom-end" class="w-fit h-fit">
-              <%= icon "dots", class: "cursor-pointer w-4 h-4" %>
-            </button>
+        <div class="flex justify-end items-center p-2 mt-1">
+          <button data-dropdown-toggle="<%= track_more_dropdown_id(track) %>" data-dropdown-placement="bottom-end" class="w-fit h-fit">
+            <%= icon "dots", class: "cursor-pointer w-4 h-4" %>
+          </button>
 
-            <%# More Dropdown %>
-            <div id="<%= track_more_dropdown_id(track) %>" class="dropdown hidden">
-              <ul>
-                <li class="dropdown-item" data-track-id="<%= track.id %>" data-action="click->audio-player#play">
-                  <%= icon "player-play", class: "aspect-square w-3" %>
-                  <%= t("label.play") %>
-                </li>
-                <li class="dropdown-item">
-                  <%= icon "pencil", class: "aspect-square w-3" %>
-                  <%= link_to t("label.edit"), edit_admin_track_path(track) %>
-                </li>
-                <li class="dropdown-item">
-                  <%= icon "eye", class: "aspect-square w-3" %>
-                  <%= link_to t("admin.see_track"), track_path(track) %>
-                </li>
-                <li class="dropdown-item text-error">
-                  <%= icon "trash", class: "aspect-square w-3" %>
-                  <%= button_to t("label.delete"), admin_track_path(track), method: :delete, data: { turbo_confirm: "Are you sure?" } %>
-                </li>
-              </ul>
-            </div>
+          <%# More Dropdown %>
+          <div id="<%= track_more_dropdown_id(track) %>" class="dropdown hidden">
+            <ul>
+              <li class="dropdown-item" data-track-id="<%= track.id %>" data-action="click->audio-player#play">
+                <%= icon "player-play", class: "aspect-square w-3" %>
+                <%= t("label.play") %>
+              </li>
+              <li class="dropdown-item">
+                <%= icon "pencil", class: "aspect-square w-3" %>
+                <%= link_to t("label.edit"), edit_admin_track_path(track) %>
+              </li>
+              <li class="dropdown-item">
+                <%= icon "eye", class: "aspect-square w-3" %>
+                <%= link_to t("admin.see_track"), track_path(track) %>
+              </li>
+              <li class="dropdown-item text-error">
+                <%= icon "trash", class: "aspect-square w-3" %>
+                <%= button_to t("label.delete"), admin_track_path(track), method: :delete, data: { turbo_confirm: "Are you sure?" } %>
+              </li>
+            </ul>
           </div>
         </div>
-      <% end %>
-    </div>
-  <% else %>
-    <p class="text-center my-10">No tracks found.</p>
-  <% end %>
-</turbo-frame>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="flex justify-center items-center w-full mt-8">
+    <%== pagy_nav(@pagy) %>
+  </div>
+<% else %>
+  <p class="text-center my-10">No tracks found.</p>
+<% end %>

--- a/app/views/admin/tracks/index.html.erb
+++ b/app/views/admin/tracks/index.html.erb
@@ -21,12 +21,6 @@
   </div>
 
   <div id="tracks" class="min-w-full">
-    <turbo-frame id="track-list">
-      <%= render partial: "admin/tracks/track_list", locals: { tracks: @tracks } %>
-    </turbo-frame>
-  </div>
-
-  <div class="flex justify-center items-center w-full mt-8">
-    <%== pagy_nav(@pagy) %>
+    <%= render partial: "admin/tracks/track_list", locals: { tracks: @tracks } %>
   </div>
 </div>

--- a/db/migrate/20250701215733_create_track_plays.rb
+++ b/db/migrate/20250701215733_create_track_plays.rb
@@ -2,7 +2,7 @@ class CreateTrackPlays < ActiveRecord::Migration[8.0]
   def change
     create_table :track_plays do |t|
       t.references :user, null: true, foreign_key: true
-      t.references :track, null: false, foreign_key: true
+      t.references :track, null: true, foreign_key: true
 
       t.timestamps
     end

--- a/db/migrate/20250718195632_nullify_model_associations_on_delete.rb
+++ b/db/migrate/20250718195632_nullify_model_associations_on_delete.rb
@@ -1,0 +1,13 @@
+class NullifyModelAssociationsOnDelete < ActiveRecord::Migration[8.0]
+  def change
+    remove_foreign_key :track_hearts, :users
+    remove_foreign_key :track_hearts, :tracks
+    remove_foreign_key :track_plays, :users
+    remove_foreign_key :track_plays, :tracks
+
+    add_foreign_key :track_hearts, :users, on_delete: :nullify
+    add_foreign_key :track_hearts, :tracks, on_delete: :nullify
+    add_foreign_key :track_plays, :users, on_delete: :nullify
+    add_foreign_key :track_plays, :tracks, on_delete: :nullify
+  end
+end

--- a/db/migrate/20250718195632_nullify_model_associations_on_delete.rb
+++ b/db/migrate/20250718195632_nullify_model_associations_on_delete.rb
@@ -9,5 +9,10 @@ class NullifyModelAssociationsOnDelete < ActiveRecord::Migration[8.0]
     add_foreign_key :track_hearts, :tracks, on_delete: :nullify
     add_foreign_key :track_plays, :users, on_delete: :nullify
     add_foreign_key :track_plays, :tracks, on_delete: :nullify
+
+    change_column_null :track_hearts, :user_id, true
+    change_column_null :track_hearts, :track_id, true
+    change_column_null :track_plays, :user_id, true
+    change_column_null :track_plays, :track_id, true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -43,8 +43,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_18_195632) do
   end
 
   create_table "track_hearts", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "track_id", null: false
+    t.bigint "user_id"
+    t.bigint "track_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["track_id"], name: "index_track_hearts_on_track_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_01_215733) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_18_195632) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -54,7 +54,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_01_215733) do
 
   create_table "track_plays", force: :cascade do |t|
     t.bigint "user_id"
-    t.bigint "track_id", null: false
+    t.bigint "track_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["track_id"], name: "index_track_plays_on_track_id"
@@ -107,9 +107,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_01_215733) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "track_hearts", "tracks"
-  add_foreign_key "track_hearts", "users"
-  add_foreign_key "track_plays", "tracks"
-  add_foreign_key "track_plays", "users"
+  add_foreign_key "track_hearts", "tracks", on_delete: :nullify
+  add_foreign_key "track_hearts", "users", on_delete: :nullify
+  add_foreign_key "track_plays", "tracks", on_delete: :nullify
+  add_foreign_key "track_plays", "users", on_delete: :nullify
   add_foreign_key "track_tags", "tracks"
 end

--- a/spec/models/track_spec.rb
+++ b/spec/models/track_spec.rb
@@ -84,7 +84,24 @@ RSpec.describe Track, type: :model do
     end
   end
 
+  describe "destroy" do
+    it "should successfully destroy track and nullify its play and hearts" do
+      user = create(:user)
+      track = create(:track)
+      heart = create(:track_heart, track_id: track.id, user_id: user.id)
+      play = create(:track_play, track_id: track.id, user_id: user.id)
 
+      expect { track.destroy }.to change { Track.count }.by(-1)
+
+      heart.reload
+      play.reload
+
+      expect(heart.track_id).to be_nil
+      expect(play.track_id).to be_nil
+      expect(heart.user_id).to eq(user.id)
+      expect(play.user_id).to eq(user.id)
+    end
+  end
 
   describe "associations" do
     it { should have_many(:hearts).dependent(:destroy) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -126,5 +126,22 @@ RSpec.describe User, type: :model do
       expect(user.display_name).to eq("Test")
       expect(user.profile_picture).to be_attached
     end
+
+    it "should successfully destroy user account and nullify its play and hearts" do
+      user = create(:user)
+      track = create(:track)
+      heart = create(:track_heart, track_id: track.id, user_id: user.id)
+      play = create(:track_play, track_id: track.id, user_id: user.id)
+
+      expect { user.destroy }.to change { User.count }.by(-1)
+
+      heart.reload
+      play.reload
+
+      expect(heart.user_id).to be_nil
+      expect(play.user_id).to be_nil
+      expect(heart.track_id).to eq(track.id)
+      expect(play.track_id).to eq(track.id)
+    end
   end
 end


### PR DESCRIPTION
## Proposed Changes
Currently Track::Play requires track_id to not be null. However if we delete the track we want to keep the play record for data reasons, so this PR nullifies related fields when a track or user is deleted.

## Type of Change
- [ ] 🚨 *Breaking change* (fix or feature that would cause existing functionality to change)
- [ ] ✨ *New feature* (non-breaking change that adds functionality)
- [ ] 🐛 *Bug fix* (non-breaking change that fixes an issue)
- [ ] 🎨 *User interface change* (change to user interface; provide screenshots)
- [ ] ♻️ *Refactoring* (internal change to codebase, without changing functionality)
- [ ] 🚦 *Test update* (change that adds or modifies tests)
- [ ] 📦 *Dependency update* (change that updates a dependency)
- [ ] 🔧 *Internal* (change that affects developers or continuous integration)


## Checklist

- [ ] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [ ] I have added tests for my changes, if applicable.
- [ ] I have updated the project documentation, if applicable.
- [ ] I have verified that the CI tests have passed.
- [ ] I have reviewed the test coverage changes reported by Coveralls.