### PR TITLE
Remove turbo frame usage in admin track list

### DIFF
--- a/app/views/admin/tracks/_track_list.html.erb
+++ b/app/views/admin/tracks/_track_list.html.erb
@@ -1,58 +1,59 @@
-<turbo-frame id="track-list">
-  <% if tracks.any? %>
-    <div class="grid [grid-template-columns:repeat(auto-fit,minmax(10rem,1fr))] gap-x-2 gap-y-8">
-      <% @tracks.each do |track| %>
-        <%# the width of the card is width of image + 2 in tailwind %>
-        <div class="flex flex-col justify-start items-stretch bg-background dark:bg-secondary-bg w-42 h-fit rounded p-1">
-          <%= render "shared/cover_photo_player", track: track, img_size: "w-40" %>
+<% if tracks.any? %>
+  <div class="grid [grid-template-columns:repeat(auto-fit,minmax(10rem,1fr))] gap-x-2 gap-y-8">
+    <% @tracks.each do |track| %>
+      <%# the width of the card is width of image + 2 in tailwind %>
+      <div class="flex flex-col justify-start items-stretch bg-background dark:bg-secondary-bg w-42 h-fit rounded p-1">
+        <%= render "shared/cover_photo_player", track: track, img_size: "w-40" %>
 
-          <div class="flex flex-col justify-start items-start gap-0.5 px-3 text-[0.6rem] mt-2 w-full">
-            <div class="flex justify-start items-stretch text-xs overflow-x-auto whitespace-nowrap w-full max-w-full">
-              <p class="truncate mb-2"><%= track.title %></p>
-              <p class="mx-1">·</p>
-              <p class="<%= track.is_public? ? "text-success" : "text-error" %>"><%= track.is_public? ? "Public" : "Private" %></p>
-            </div>
-            <%= render "tracks/track_data", track: track, icon_size: "3" %>
+        <div class="flex flex-col justify-start items-start gap-0.5 px-3 text-[0.6rem] mt-2 w-full">
+          <div class="flex justify-start items-stretch text-xs overflow-x-auto whitespace-nowrap w-full max-w-full">
+            <p class="truncate mb-2"><%= track.title %></p>
+            <p class="mx-1">·</p>
+            <p class="<%= track.is_public? ? "text-success" : "text-error" %>"><%= track.is_public? ? "Public" : "Private" %></p>
           </div>
+          <%= render "tracks/track_data", track: track, icon_size: "3" %>
+        </div>
 
-          <div class="flex justify-between items-center text-[0.6rem] px-1 mt-4">
-            <div class="<%= track_file_upload_indicator_styles(track.tagged_mp3) %>">Tagged</div>
-            <div class="<%= track_file_upload_indicator_styles(track.untagged_mp3) %>">MP3</div>
-            <div class="<%= track_file_upload_indicator_styles(track.untagged_wav) %>">WAV</div>
-            <div class="<%= track_file_upload_indicator_styles(track.track_stems) %>">ZIP</div>
-          </div>
+        <div class="flex justify-between items-center text-[0.6rem] px-1 mt-4">
+          <div class="<%= track_file_upload_indicator_styles(track.tagged_mp3) %>">Tagged</div>
+          <div class="<%= track_file_upload_indicator_styles(track.untagged_mp3) %>">MP3</div>
+          <div class="<%= track_file_upload_indicator_styles(track.untagged_wav) %>">WAV</div>
+          <div class="<%= track_file_upload_indicator_styles(track.track_stems) %>">ZIP</div>
+        </div>
 
-          <div class="flex justify-end items-center p-2 mt-1">
-            <button data-dropdown-toggle="<%= track_more_dropdown_id(track) %>" data-dropdown-placement="bottom-end" class="w-fit h-fit">
-              <%= icon "dots", class: "cursor-pointer w-4 h-4" %>
-            </button>
+        <div class="flex justify-end items-center p-2 mt-1">
+          <button data-dropdown-toggle="<%= track_more_dropdown_id(track) %>" data-dropdown-placement="bottom-end" class="w-fit h-fit">
+            <%= icon "dots", class: "cursor-pointer w-4 h-4" %>
+          </button>
 
-            <%# More Dropdown %>
-            <div id="<%= track_more_dropdown_id(track) %>" class="dropdown hidden">
-              <ul>
-                <li class="dropdown-item" data-track-id="<%= track.id %>" data-action="click->audio-player#play">
-                  <%= icon "player-play", class: "aspect-square w-3" %>
-                  <%= t("label.play") %>
-                </li>
-                <li class="dropdown-item">
-                  <%= icon "pencil", class: "aspect-square w-3" %>
-                  <%= link_to t("label.edit"), edit_admin_track_path(track) %>
-                </li>
-                <li class="dropdown-item">
-                  <%= icon "eye", class: "aspect-square w-3" %>
-                  <%= link_to t("admin.see_track"), track_path(track) %>
-                </li>
-                <li class="dropdown-item text-error">
-                  <%= icon "trash", class: "aspect-square w-3" %>
-                  <%= button_to t("label.delete"), admin_track_path(track), method: :delete, data: { turbo_confirm: "Are you sure?" } %>
-                </li>
-              </ul>
-            </div>
+          <%# More Dropdown %>
+          <div id="<%= track_more_dropdown_id(track) %>" class="dropdown hidden">
+            <ul>
+              <li class="dropdown-item" data-track-id="<%= track.id %>" data-action="click->audio-player#play">
+                <%= icon "player-play", class: "aspect-square w-3" %>
+                <%= t("label.play") %>
+              </li>
+              <li class="dropdown-item">
+                <%= icon "pencil", class: "aspect-square w-3" %>
+                <%= link_to t("label.edit"), edit_admin_track_path(track) %>
+              </li>
+              <li class="dropdown-item">
+                <%= icon "eye", class: "aspect-square w-3" %>
+                <%= link_to t("admin.see_track"), track_path(track) %>
+              </li>
+              <li class="dropdown-item text-error">
+                <%= icon "trash", class: "aspect-square w-3" %>
+                <%= button_to t("label.delete"), admin_track_path(track), method: :delete, data: { turbo_confirm: "Are you sure?" } %>
+              </li>
+            </ul>
           </div>
         </div>
-      <% end %>
-    </div>
-  <% else %>
-    <p class="text-center my-10">No tracks found.</p>
-  <% end %>
-</turbo-frame>
+      </div>
+    <% end %>
+  </div>
+  <div class="flex justify-center items-center w-full mt-8">
+    <%== pagy_nav(@pagy) %>
+  </div>
+<% else %>
+  <p class="text-center my-10">No tracks found.</p>
+<% end %>

--- a/app/views/admin/tracks/index.html.erb
+++ b/app/views/admin/tracks/index.html.erb
@@ -21,12 +21,6 @@
   </div>
 
   <div id="tracks" class="min-w-full">
-    <turbo-frame id="track-list">
-      <%= render partial: "admin/tracks/track_list", locals: { tracks: @tracks } %>
-    </turbo-frame>
-  </div>
-
-  <div class="flex justify-center items-center w-full mt-8">
-    <%== pagy_nav(@pagy) %>
+    <%= render partial: "admin/tracks/track_list", locals: { tracks: @tracks } %>
   </div>
 </div>

--- a/app/views/shared/_cover_photo_player.html.erb
+++ b/app/views/shared/_cover_photo_player.html.erb
@@ -1,4 +1,4 @@
-<div class="<%= "relative flex justify-center items-center bg-secondary-bg dark:bg-background aspect-square #{img_size} rounded cursor-pointer" %>"
+<div class="<%= "relative flex justify-center items-center bg-secondary-bg aspect-square #{img_size} rounded cursor-pointer" %>"
   data-controller="cover-photo-hover" data-cover-photo-hover-target="container">
   <% if track.cover_photo.attached? %>
     <%= image_tag track.cover_photo, class: "object-cover w-full h-full rounded" %>


### PR DESCRIPTION
## Proposed Changes
From the infinite scroll change #99 we decided to not re-render track queries through turbo frame. This PR removes the turbo frames used for admin track list.

## Type of Change
- [ ] 🚨 *Breaking change* (fix or feature that would cause existing functionality to change)
- [ ] ✨ *New feature* (non-breaking change that adds functionality)
- [x] 🐛 *Bug fix* (non-breaking change that fixes an issue)
- [x] 🎨 *User interface change* (change to user interface; provide screenshots)
- [ ] ♻️ *Refactoring* (internal change to codebase, without changing functionality)
- [ ] 🚦 *Test update* (change that adds or modifies tests)
- [ ] 📦 *Dependency update* (change that updates a dependency)
- [ ] 🔧 *Internal* (change that affects developers or continuous integration)


## Checklist

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [ ] I have added tests for my changes, if applicable.
- [ ] I have updated the project documentation, if applicable.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.