### PR TITLE
Limit overflow to vertical only for main page content

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,7 +27,7 @@
     data-controller="audio-player">
     <%= render "nav/navbar" %>
 
-    <main id="main" class="flex-1 overflow-scroll">
+    <main id="main" class="flex-1 overflow-y-scroll">
       <%= render current_page %>
     </main>
 


### PR DESCRIPTION
## Proposed Changes
As title, having overflow in both directions will add the scrollbar when using mouse and its ugly as fuck.

## Type of Change
- [ ] 🚨 *Breaking change* (fix or feature that would cause existing functionality to change)
- [ ] ✨ *New feature* (non-breaking change that adds functionality)
- [ ] 🐛 *Bug fix* (non-breaking change that fixes an issue)
- [x] 🎨 *User interface change* (change to user interface; provide screenshots)
- [ ] ♻️ *Refactoring* (internal change to codebase, without changing functionality)
- [ ] 🚦 *Test update* (change that adds or modifies tests)
- [ ] 📦 *Dependency update* (change that updates a dependency)
- [ ] 🔧 *Internal* (change that affects developers or continuous integration)


## Checklist

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [ ] I have added tests for my changes, if applicable.
- [ ] I have updated the project documentation, if applicable.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.