### PR TITLE
Store and serve files with original filename

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -9,15 +9,15 @@ class DownloadsController < ApplicationController
     end
 
     send_data @track.tagged_mp3.download,
-      filename: set_file_name(@track, "mp3"),
-      type: :mp3,
+      filename: set_file_name(@track.tagged_mp3),
+      type: "audio/mpeg",
       disposition: "attachment"
   end
 
   private
 
-  def set_file_name(track, extension)
-    "#{track.title} - #{track.bpm}bpm #{track.key.downcase}.#{extension}"
+  def set_file_name(file)
+    file.filename.to_s
   end
 
   def file_exists?(file)

--- a/app/javascript/controllers/upload_controller.js
+++ b/app/javascript/controllers/upload_controller.js
@@ -64,7 +64,7 @@ export default class extends Controller {
       if (!blob) return;
 
       const filename = `${crypto.randomUUID().replace(/-/g, '')}.png`;
-      const file = new File([blob], filename, { type: "image/jpeg" });
+      const file = new File([blob], filename, { type: "image/png" });
 
       const dataTransfer = new DataTransfer();
       dataTransfer.items.add(file);

--- a/app/javascript/controllers/upload_controller.js
+++ b/app/javascript/controllers/upload_controller.js
@@ -63,7 +63,8 @@ export default class extends Controller {
     cropper.getCroppedCanvas().toBlob((blob) => {
       if (!blob) return;
 
-      const file = new File([blob], "cropped-image.png", { type: "image/jpeg" });
+      const filename = `${crypto.randomUUID().replace(/-/g, '')}.png`;
+      const file = new File([blob], filename, { type: "image/jpeg" });
 
       const dataTransfer = new DataTransfer();
       dataTransfer.items.add(file);

--- a/spec/factories/tracks.rb
+++ b/spec/factories/tracks.rb
@@ -20,19 +20,19 @@ FactoryBot.define do
         filename: "tagged_mp3.mp3",
         content_type: "audio/mpeg"
       )
-      track.tagged_mp3.attach(
+      track.untagged_mp3.attach(
         io: File.open(Rails.root.join("spec", "fixtures", "files", "tracks", "untagged_mp3.mp3")),
         filename: "untagged_mp3.mp3",
         content_type: "audio/mpeg"
       )
-      track.tagged_mp3.attach(
+      track.untagged_wav.attach(
         io: File.open(Rails.root.join("spec", "fixtures", "files", "tracks", "untagged_wav.wav")),
-        filename: "untagged_wav.mp3",
+        filename: "untagged_wav.wav",
         content_type: "audio/wav"
       )
-      track.tagged_mp3.attach(
+      track.track_stems.attach(
         io: File.open(Rails.root.join("spec", "fixtures", "files", "tracks", "track_stems.zip")),
-        filename: "track_stems.mp3",
+        filename: "track_stems.zip",
         content_type: "application/zip"
       )
     end

--- a/spec/requests/downloads_spec.rb
+++ b/spec/requests/downloads_spec.rb
@@ -12,21 +12,20 @@ RSpec.describe DownloadsController, type: :request do
       end
 
       it "#free_download returns the file as attachment for track" do
-        get download_track_free_url(track.id)
+        get download_track_free_url(track)
 
         expect(response).to have_http_status(:ok)
         expect(response.headers["Content-Disposition"]).to include("attachment")
-        expect(response.headers['Content-Disposition']).to include("filename=\"#{"Track with files - 111bpm c major.mp3"}\"")
+        expect(response.headers['Content-Disposition']).to include("filename=\"tagged_mp3.mp3\"")
         expect(response.content_type).to eq("audio/mpeg")
       end
 
       it "#free_download should let unauthed users download" do
-        get download_track_free_url(track.id)
+        get download_track_free_url(track)
 
         expect(response).to have_http_status(:ok)
         expect(response.headers["Content-Disposition"]).to include("attachment")
-        # TODO replace with track.tagged_mp3.blob.filename when frontend is updated to take the original file name uploaded
-        expect(response.headers['Content-Disposition']).to include("filename=\"#{"Track with files - 111bpm c major.mp3"}\"")
+        expect(response.headers['Content-Disposition']).to include("filename=\"tagged_mp3.mp3\"")
         expect(response.content_type).to eq("audio/mpeg")
       end
     end


### PR DESCRIPTION
## Proposed Changes
This PR stores and serves files with the original name of the file that was uploaded.
- For images, the uploaded images are given a static file name. This change generates a uuid as its filename instead.
- For tracks, the served file name is constructed. This change loads the original name stored instead.

## Type of Change
- [ ] 🚨 *Breaking change* (fix or feature that would cause existing functionality to change)
- [ ] ✨ *New feature* (non-breaking change that adds functionality)
- [ ] 🐛 *Bug fix* (non-breaking change that fixes an issue)
- [ ] 🎨 *User interface change* (change to user interface; provide screenshots)
- [ ] ♻️ *Refactoring* (internal change to codebase, without changing functionality)
- [ ] 🚦 *Test update* (change that adds or modifies tests)
- [ ] 📦 *Dependency update* (change that updates a dependency)
- [ ] 🔧 *Internal* (change that affects developers or continuous integration)


## Checklist

- [ ] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [ ] I have added tests for my changes, if applicable.
- [ ] I have updated the project documentation, if applicable.
- [ ] I have verified that the CI tests have passed.
- [ ] I have reviewed the test coverage changes reported by Coveralls.