### PR TITLE
Fix contract document not rendering on license create

### DIFF
--- a/app/views/contracts/tracks/_form.html.erb
+++ b/app/views/contracts/tracks/_form.html.erb
@@ -214,7 +214,7 @@
 
         <div class="field content-input-container">
           <%= c.text_area :document_template,
-            value: license.contract[:document_template].nil? ? License.track_contract_templates[contract_type] : license.contract[:document_template],
+            value: license.persisted? ? license.contract[:document_template] : License.track_contract_templates[contract_type],
             autocomplete: "off", class: "content-input h-80 min-h-10 font-light" %>
         </div>
       </section>

--- a/config/initializers/templates.rb
+++ b/config/initializers/templates.rb
@@ -4,7 +4,7 @@ class Templates
   class << self
     def read_contract_templates
       track_free = License.contract_types[:free]
-      track_non_exclusive = License.contract_types[:free]
+      track_non_exclusive = License.contract_types[:non_exclusive]
 
       {
         "#{track_free}" => read_template("templates/contracts/tracks/free.md"),


### PR DESCRIPTION
## Proposed Changes
The default contract document template didn't render for non exclusive contracts due to incorrect key in the initializer.

## Type of Change
- [ ] 🚨 *Breaking change* (fix or feature that would cause existing functionality to change)
- [ ] ✨ *New feature* (non-breaking change that adds functionality)
- [x] 🐛 *Bug fix* (non-breaking change that fixes an issue)
- [ ] 🎨 *User interface change* (change to user interface; provide screenshots)
- [ ] ♻️ *Refactoring* (internal change to codebase, without changing functionality)
- [ ] 🚦 *Test update* (change that adds or modifies tests)
- [ ] 📦 *Dependency update* (change that updates a dependency)
- [ ] 🔧 *Internal* (change that affects developers or continuous integration)


## Checklist

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [ ] I have added tests for my changes, if applicable.
- [ ] I have updated the project documentation, if applicable.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.