### PR TITLE
Model orders and order items

### DIFF
--- a/app/models/cart_item.rb
+++ b/app/models/cart_item.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 class CartItem < ApplicationRecord
+  include Purchasable
+
   validates :quantity, numericality: { only_integer: true, greater_than: 0 }, presence: true
   validates :product_type, inclusion: {
-    in: :valid_product_types,
+    in: ->() { valid_product_types },
     message: "%{value} is not a valid entity type"
   }, if: -> { product.present? }
   validates :license_id, uniqueness: { scope: [ :cart_id, :product_id, :product_type, :license_id ],
@@ -13,21 +15,9 @@ class CartItem < ApplicationRecord
   belongs_to :license, optional: true
   belongs_to :cart, optional: false
 
-  class << self
-    def valid_product_types
-      [ Track ].map { |p| p.name }
-    end
-  end
-
   def available?
     license.present? && product.present?
     # TODO also need to check product state, e.g. if track is private or not.
     # do this after non exclusive license is implemented or smth
-  end
-
-  private
-
-  def valid_product_types
-    CartItem.valid_product_types
   end
 end

--- a/app/models/concerns/purchasable.rb
+++ b/app/models/concerns/purchasable.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Purchasable
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def valid_product_types
+      [ Track ].map(&:name)
+    end
+  end
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -6,7 +6,7 @@ class Order < ApplicationRecord
 
   enum status: {
     pending: "pending",
-    paid: "paid",
+    completed: "completed",
     failed: "failed"
   }
 
@@ -14,14 +14,19 @@ class Order < ApplicationRecord
   validates :subtotal_cents, numericality: { greater_than_or_equal_to: 0 }
 
   before_update :prevent_core_changes_if_paid
+  before_destroy :prevent_destroy
 
   private
 
-  # enforce immutability after payment
+  # immutability after payment
   def prevent_core_changes_if_paid
     if paid? && (changed & %w[subtotal_cents currency user_id]).any?
       errors.add(:base, "Cannot modify order details once paid")
       throw(:abort)
     end
+  end
+
+  def prevent_destroy
+    raise ActiveRecord::ReadOnlyRecord, "Orders are immutable"
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -19,7 +19,7 @@ class Order < ApplicationRecord
 
   # enforce immutability after payment
   def prevent_core_changes_if_paid
-    if paid? && (changed & %w[total_cents currency user_id]).any?
+    if paid? && (changed & %w[subtotal_cents currency user_id]).any?
       errors.add(:base, "Cannot modify order details once paid")
       throw(:abort)
     end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -28,8 +28,7 @@ class Order < ApplicationRecord
 
   def prevent_updates_except_status
     unless status_was == Order.statuses[:pending]
-      errors.add(:base, "Cannot modify order details once transaction completed or failed")
-      throw(:abort)
+      raise ActiveRecord::ReadOnlyRecord, "Cannot modify order details once transaction completed or failed"
     end
 
     if (changed - %w[status updated_at]).any?

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# This should be partly immutable except for status updates. Once transaction clears it should be readonly
 class Order < ApplicationRecord
   belongs_to :user
   has_many :order_items, dependent: :restrict_with_error

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Order < ApplicationRecord
+  belongs_to :user
+  has_many :order_items, dependent: :restrict_with_error
+
+  enum status: {
+    pending: "pending",
+    paid: "paid",
+    failed: "failed"
+  }
+
+  validates :currency, presence: true
+  validates :subtotal_cents, numericality: { greater_than_or_equal_to: 0 }
+
+  before_update :prevent_core_changes_if_paid
+
+  private
+
+  # enforce immutability after payment
+  def prevent_core_changes_if_paid
+    if paid? && (changed & %w[total_cents currency user_id]).any?
+      errors.add(:base, "Cannot modify order details once paid")
+      throw(:abort)
+    end
+  end
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -4,7 +4,7 @@ class Order < ApplicationRecord
   belongs_to :user
   has_many :order_items, dependent: :restrict_with_error
 
-  enum status: {
+  enum :status, {
     pending: "pending",
     completed: "completed",
     failed: "failed"

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -6,9 +6,10 @@ class OrderItem < ApplicationRecord
   has_many_attached :files
 
   validates :public_id, presence: true, uniqueness: true
-  validates :track_snapshot, :license_snapshot, presence: true
   validates :quantity, numericality: { greater_than: 0 }
   validates :unit_price_cents, numericality: { greater_than_or_equal_to: 0 }
+  validates :product_snapshot, :license_snapshot, presence: true
+  validates :product_type, inclusion: { in: ->() { valid_product_types }, message: "%{value} is not a valid entity type" }
 
   before_update :prevent_update_unless_attaching_files
   before_destroy :prevent_destroy

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -33,16 +33,8 @@ class OrderItem < ApplicationRecord
       raise ActiveRecord::ReadOnlyRecord, "OrderItem is immutable after order is completed or failed"
     end
 
-    files_being_attached = attachment_changes[:files].present?
-    other_changes = changed - [ "updated_at" ]
-
-    if other_changes.any?
-      raise ActiveRecord::ReadOnlyRecord, "OrderItem is immutable except for attaching files before payment"
-    end
-
-    unless files_being_attached
-      raise ActiveRecord::ReadOnlyRecord, "OrderItem is immutable except for attaching files before payment"
-    end
+    errors.add(:base, "Cannot modify order item details other than attaching files")
+    throw(:abort)
   end
 
   def prevent_destroy

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -2,19 +2,31 @@
 
 # This should be immutable, except when attaching files
 class OrderItem < ApplicationRecord
+  include Purchasable
+
+  PUBLIC_ID_PREFIX = "OI"
+  PUBLIC_ID_SUFFIX_LENGTH = 8
+
   belongs_to :order
   has_many_attached :files
 
   validates :public_id, presence: true, uniqueness: true
   validates :quantity, numericality: { greater_than: 0 }
   validates :unit_price_cents, numericality: { greater_than_or_equal_to: 0 }
-  validates :product_snapshot, :license_snapshot, presence: true
+  validates :product_snapshot, :license_snapshot, :currency, presence: true
   validates :product_type, inclusion: { in: ->() { valid_product_types }, message: "%{value} is not a valid entity type" }
 
+  before_validation :generate_public_id, if: :new_record?
   before_update :prevent_update_unless_attaching_files
   before_destroy :prevent_destroy
 
   private
+
+  def generate_public_id
+    timestamp = Time.current.strftime("%y%m%d%H%M%S")
+    suffix = SecureRandom.alphanumeric(PUBLIC_ID_SUFFIX_LENGTH)
+    self.public_id = "#{PUBLIC_ID_PREFIX}_#{timestamp}_#{suffix}"
+  end
 
   def prevent_update_unless_attaching_files
     unless order.status == Order.statuses[:pending]

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# This should be immutable, except when attaching files
+class OrderItem < ApplicationRecord
+  belongs_to :order
+  has_many_attached :files
+
+  validates :public_id, presence: true, uniqueness: true
+  validates :track_snapshot, :license_snapshot, presence: true
+  validates :quantity, numericality: { greater_than: 0 }
+  validates :unit_price_cents, numericality: { greater_than_or_equal_to: 0 }
+
+  before_update :prevent_update_unless_attaching_files
+  before_destroy :prevent_destroy
+
+  private
+
+  def prevent_update_unless_attaching_files
+    unless order.status == Order.statuses[:pending]
+      raise ActiveRecord::ReadOnlyRecord, "OrderItem is immutable after order is completed or failed"
+    end
+
+    files_being_attached = attachment_changes[:files].present?
+    other_changes = changed - [ "updated_at" ]
+
+    if other_changes.any?
+      raise ActiveRecord::ReadOnlyRecord, "OrderItem is immutable except for attaching files before payment"
+    end
+
+    unless files_being_attached
+      raise ActiveRecord::ReadOnlyRecord, "OrderItem is immutable except for attaching files before payment"
+    end
+  end
+
+  def prevent_destroy
+    raise ActiveRecord::ReadOnlyRecord, "OrderItems are immutable"
+  end
+end

--- a/db/migrate/20250906171126_add_orders.rb
+++ b/db/migrate/20250906171126_add_orders.rb
@@ -1,0 +1,13 @@
+class AddOrders < ActiveRecord::Migration[8.0]
+  def change
+    create_table :orders do |t|
+      t.references :user, null: false, foreign_key: true
+      t.integer :subtotal_cents, null: false, default: 0
+      t.string  :currency, null: false, default: "usd"
+      t.string :status, null: false
+      t.jsonb :metadata, default: {}
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250906174232_add_order_items.rb
+++ b/db/migrate/20250906174232_add_order_items.rb
@@ -1,17 +1,20 @@
 class AddOrderItems < ActiveRecord::Migration[8.0]
   def change
     create_table :order_items do |t|
-      t.uuid :public_id, null: false
+      t.string :public_id, null: false
       t.integer :quantity, null: false, default: 1
       t.references :order, null: false, foreign_key: true
 
       # snapshots
       t.integer :unit_price_cents, null: false
+      t.string :currency, null: false
       t.string :product_type, null: false
       t.jsonb :product_snapshot, default: {}, null: false
       t.jsonb :license_snapshot, default: {}, null: false
 
       t.timestamps
     end
+
+    add_index :order_items, :public_id, unique: true
   end
 end

--- a/db/migrate/20250906174232_add_order_items.rb
+++ b/db/migrate/20250906174232_add_order_items.rb
@@ -1,0 +1,17 @@
+class AddOrderItems < ActiveRecord::Migration[8.0]
+  def change
+    create_table :order_items do |t|
+      t.uuid :public_id, null: false
+      t.integer :quantity, null: false, default: 1
+      t.references :order, null: false, foreign_key: true
+
+      # snapshots
+      t.integer :unit_price_cents, null: false
+      t.string :product_type, null: false
+      t.jsonb :product_snapshot, default: {}, null: false
+      t.jsonb :license_snapshot, default: {}, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -121,16 +121,18 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_06_174232) do
   end
 
   create_table "order_items", force: :cascade do |t|
-    t.uuid "public_id", null: false
+    t.string "public_id", null: false
     t.integer "quantity", default: 1, null: false
     t.bigint "order_id", null: false
     t.integer "unit_price_cents", null: false
+    t.string "currency", null: false
     t.string "product_type", null: false
     t.jsonb "product_snapshot", default: {}, null: false
     t.jsonb "license_snapshot", default: {}, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["order_id"], name: "index_order_items_on_order_id"
+    t.index ["public_id"], name: "index_order_items_on_public_id", unique: true
   end
 
   create_table "orders", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_06_171126) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_06_174232) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -120,6 +120,19 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_06_171126) do
     t.index ["track_id"], name: "index_licenses_tracks_on_track_id"
   end
 
+  create_table "order_items", force: :cascade do |t|
+    t.uuid "public_id", null: false
+    t.integer "quantity", default: 1, null: false
+    t.bigint "order_id", null: false
+    t.integer "unit_price_cents", null: false
+    t.string "product_type", null: false
+    t.jsonb "product_snapshot", default: {}, null: false
+    t.jsonb "license_snapshot", default: {}, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["order_id"], name: "index_order_items_on_order_id"
+  end
+
   create_table "orders", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.integer "subtotal_cents", default: 0, null: false
@@ -214,6 +227,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_06_171126) do
   add_foreign_key "comments", "users"
   add_foreign_key "licenses_tracks", "licenses"
   add_foreign_key "licenses_tracks", "tracks"
+  add_foreign_key "order_items", "orders"
   add_foreign_key "orders", "users"
   add_foreign_key "samples", "tracks"
   add_foreign_key "track_hearts", "tracks", on_delete: :nullify

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_03_154231) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_06_171126) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -120,6 +120,17 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_03_154231) do
     t.index ["track_id"], name: "index_licenses_tracks_on_track_id"
   end
 
+  create_table "orders", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.integer "subtotal_cents", default: 0, null: false
+    t.string "currency", default: "usd", null: false
+    t.string "status", null: false
+    t.jsonb "metadata", default: {}
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_orders_on_user_id"
+  end
+
   create_table "samples", force: :cascade do |t|
     t.string "name", null: false
     t.string "artist", default: ""
@@ -203,6 +214,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_03_154231) do
   add_foreign_key "comments", "users"
   add_foreign_key "licenses_tracks", "licenses"
   add_foreign_key "licenses_tracks", "tracks"
+  add_foreign_key "orders", "users"
   add_foreign_key "samples", "tracks"
   add_foreign_key "track_hearts", "tracks", on_delete: :nullify
   add_foreign_key "track_hearts", "users", on_delete: :nullify

--- a/spec/factories/order.rb
+++ b/spec/factories/order.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :order do
+    subtotal_cents { 2000 }
+    currency { "USD" }
+    status { Order.statuses[:pending] }
+    metadata { {} }
+
+    association :user
+  end
+end

--- a/spec/factories/order_item.rb
+++ b/spec/factories/order_item.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :order_item do
+    public_id { nil }
+    quantity { 1 }
+    unit_price_cents { 2000 }
+    currency { "USD" }
+    product_type { Track.name }
+    product_snapshot { { test: "test" } }
+    license_snapshot { { test: "test" } }
+
+    association :order
+  end
+end

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe OrderItem, type: :model do
+  let(:order) { create(:order) }
+  let!(:order_item) { create(:order_item, order:) }
+
+  it { should belong_to(:order) }
+  it { should have_many_attached(:files) }
+  it { should validate_presence_of(:product_snapshot) }
+  it { should validate_presence_of(:license_snapshot) }
+  it { should validate_presence_of(:currency) }
+  it { should validate_numericality_of(:unit_price_cents).is_greater_than_or_equal_to(0) }
+
+  describe "validations" do
+    it "requires a public_id" do
+      order_item.public_id = nil
+      expect(order_item).not_to be_valid
+      expect(order_item.errors[:public_id]).to include("is required")
+    end
+
+    it "allows purchasable products" do
+      [ Track.name ].each do |type|
+        order_item.product_type = type
+        expect(order_item).to be_valid
+      end
+    end
+
+    it "validates product_type inclusion" do
+      order_item.product_type = "invalid"
+      expect(order_item).not_to be_valid
+      expect(order_item.errors[:product_type]).to include("invalid is not a valid entity type")
+    end
+  end
+end

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -51,6 +51,15 @@ RSpec.describe OrderItem, type: :model do
         expect(order_item.files.attached?).to be(true)
         expect(order_item.files.first.filename.to_s).to eq("tagged_mp3.mp3")
       end
+
+      it "should allow order items to be associated with an order" do
+        oi = create(:order_item, order:)
+        order.reload
+
+        expect(order.order_items.count).to eq(2)
+        expect(order.order_items.last).to eq(oi)
+        expect(oi.order.id).to eq(order.id)
+      end
     end
 
     context "order is completed" do
@@ -71,6 +80,12 @@ RSpec.describe OrderItem, type: :model do
           )
         }.to raise_error(ActiveRecord::ReadOnlyRecord, "OrderItem is immutable after order is completed or failed")
       end
+
+      it "should not allow new associations to order" do
+        order_item = build(:order_item, order:)
+        expect { order_item.save! }.to raise_error(ActiveRecord::RecordNotSaved)
+        expect(order_item.errors[:base]).to include("Couldn't create order item as associated order's transaction has completed or failed")
+      end
     end
 
     context "order has failed" do
@@ -90,6 +105,12 @@ RSpec.describe OrderItem, type: :model do
             content_type: "audio/mpeg"
           )
         }.to raise_error(ActiveRecord::ReadOnlyRecord, "OrderItem is immutable after order is completed or failed")
+      end
+
+      it "should not allow new associations to order" do
+        order_item = build(:order_item, order:)
+        expect { order_item.save! }.to raise_error(ActiveRecord::RecordNotSaved)
+        expect(order_item.errors[:base]).to include("Couldn't create order item as associated order's transaction has completed or failed")
       end
     end
 

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Order, type: :model do
         }.to change { order.reload.status }.from(Order.statuses[:pending]).to(Order.statuses[:failed])
       end
 
-      it "does not allow anything other than status updates" do
+      it "does not allow any column updates other than status updates" do
         expect {
           order.update!(subtotal_cents: 1111)
         }.to raise_error(ActiveRecord::RecordNotSaved)
@@ -63,13 +63,13 @@ RSpec.describe Order, type: :model do
       before { order.update!(status: Order.statuses[:completed]) }
 
       it "does not allow any updates" do
-        expect { order.update!(subtotal_cents: 2222) }.to raise_error(ActiveRecord::RecordNotSaved)
+        expect { order.update!(subtotal_cents: 2222) }.to raise_error(ActiveRecord::ReadOnlyRecord)
         expect(order.errors[:base]).to include("Cannot modify order details once transaction completed or failed")
         expect(order.reload.subtotal_cents).to eq(2000)
       end
 
       it "does not allow status updates" do
-        expect { order.update!(status: Order.statuses[:failed]) }.to raise_error(ActiveRecord::RecordNotSaved)
+        expect { order.update!(status: Order.statuses[:failed]) }.to raise_error(ActiveRecord::ReadOnlyRecord)
 
         expect(order.reload.status).to eq(Order.statuses[:completed])
       end
@@ -79,13 +79,13 @@ RSpec.describe Order, type: :model do
       before { order.update!(status: Order.statuses[:failed]) }
 
       it "does not allow any updates" do
-        expect { order.update!(currency: "CAD") }.to raise_error(ActiveRecord::RecordNotSaved)
+        expect { order.update!(currency: "CAD") }.to raise_error(ActiveRecord::ReadOnlyRecord)
         expect(order.errors[:base]).to include("Cannot modify order details once transaction completed or failed")
         expect(order.reload.currency).to eq("USD")
       end
 
       it "does not allow status updates" do
-        expect { order.update!(status: Order.statuses[:completed]) }.to raise_error(ActiveRecord::RecordNotSaved)
+        expect { order.update!(status: Order.statuses[:completed]) }.to raise_error(ActiveRecord::ReadOnlyRecord)
         expect(order.reload.status).to eq(Order.statuses[:failed])
       end
     end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Order, type: :model do
+  let(:user) { create(:user) }
+
+  describe "validations" do
+    it { should validate_presence_of(:currency) }
+    it { should validate_presence_of(:subtotal_cents) }
+    it { should validate_numericality_of(:subtotal_cents).is_greater_than_or_equal_to(0) }
+  end
+
+  describe "associations" do
+    it { should belong_to(:user) }
+    it { should have_many(:order_items).dependent(:restrict_with_error) }
+  end
+
+  describe "statuses" do
+    subject(:order) { build(:order) }
+
+    it "allows the following statuses" do
+      [ "pending", "completed", "failed" ].each do |status|
+        subject.status = status
+        expect(subject).to be_valid
+      end
+    end
+
+    it "does not accept invalid statuses" do
+      expect {
+        subject.status = "invalid"
+      }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "immutability" do
+    let!(:order) { create(:order, user: user) }
+
+    context "when status is pending" do
+      it "can update status to completed" do
+        expect {
+          order.update!(status: Order.statuses[:completed])
+        }.to change { order.reload.status }.from(Order.statuses[:pending]).to(Order.statuses[:completed])
+      end
+
+      it "can update status to failed" do
+        expect {
+          order.update!(status: Order.statuses[:failed])
+        }.to change { order.reload.status }.from(Order.statuses[:pending]).to(Order.statuses[:failed])
+      end
+
+      it "does not allow anything other than status updates" do
+        expect {
+          order.update!(subtotal_cents: 1111)
+        }.to raise_error(ActiveRecord::RecordNotSaved)
+        order.reload
+
+        expect(order.errors.full_messages).to include("Cannot modify order details other than status")
+      end
+    end
+
+    context "when status is completed" do
+      before { order.update!(status: Order.statuses[:completed]) }
+
+      it "does not allow any updates" do
+        expect { order.update!(subtotal_cents: 2222) }.to raise_error(ActiveRecord::RecordNotSaved)
+        expect(order.errors[:base]).to include("Cannot modify order details once transaction completed or failed")
+        expect(order.reload.subtotal_cents).to eq(2000)
+      end
+
+      it "does not allow status updates" do
+        expect { order.update!(status: Order.statuses[:failed]) }.to raise_error(ActiveRecord::RecordNotSaved)
+
+        expect(order.reload.status).to eq(Order.statuses[:completed])
+      end
+    end
+
+    context "when status is failed" do
+      before { order.update!(status: Order.statuses[:failed]) }
+
+      it "does not allow any updates" do
+        expect { order.update!(currency: "CAD") }.to raise_error(ActiveRecord::RecordNotSaved)
+        expect(order.errors[:base]).to include("Cannot modify order details once transaction completed or failed")
+        expect(order.reload.currency).to eq("USD")
+      end
+
+      it "does not allow status updates" do
+        expect { order.update!(status: Order.statuses[:completed]) }.to raise_error(ActiveRecord::RecordNotSaved)
+        expect(order.reload.status).to eq(Order.statuses[:failed])
+      end
+    end
+
+    context "destroying" do
+      it "raises an error for destroy" do
+        expect { order.destroy }.to raise_error(ActiveRecord::ReadOnlyRecord, "Orders are immutable")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Proposed Changes
Model orders and order items with immutability guards. Currently, orders should only have status being immutable and become readonly when transaction clears (i.e. status has completed or failed). 

Order item should be immutable for all columns, except the attaching new files. Once the associated order is completed, order item is readonly. The reason we allow file attachment is we want to duplicate the delivered files which should ALWAYS exist. We create orders and order items when a checkout session begins, however, the user may not complete the purchase which will take up extra unused space in storage. Therefore we want to duplicate the files after a transaction succeeds so we allow file attachments before we update order status to complete.

## Type of Change
- [ ] 🚨 *Breaking change* (fix or feature that would cause existing functionality to change)
- [ ] ✨ *New feature* (non-breaking change that adds functionality)
- [ ] 🐛 *Bug fix* (non-breaking change that fixes an issue)
- [ ] 🎨 *User interface change* (change to user interface; provide screenshots)
- [ ] ♻️ *Refactoring* (internal change to codebase, without changing functionality)
- [ ] 🚦 *Test update* (change that adds or modifies tests)
- [ ] 📦 *Dependency update* (change that updates a dependency)
- [ ] 🔧 *Internal* (change that affects developers or continuous integration)


## Checklist

- [ ] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [ ] I have added tests for my changes, if applicable.
- [ ] I have updated the project documentation, if applicable.
- [ ] I have verified that the CI tests have passed.
- [ ] I have reviewed the test coverage changes reported by Coveralls.