### PR TITLE
Don't load Stripe configuration if not present

### DIFF
--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -5,5 +5,9 @@ STRIPE_CONFIG = Rails.application.credentials.dig(
   Rails.env.production? ? :live : :test
 )
 
-Stripe.api_key = STRIPE_CONFIG[:secret_key]
-STRIPE_PAYMENTS_WEBHOOK_SECRET = STRIPE_CONFIG[:payments_webhook_secret]
+# We'll have to skip Stripe configs in cases such as dependabot PRs,
+# because dependabots cannot access project secrets so it fails
+if STRIPE_CONFIG.present?
+  Stripe.api_key = STRIPE_CONFIG[:secret_key]
+  STRIPE_PAYMENTS_WEBHOOK_SECRET = STRIPE_CONFIG[:payments_webhook_secret]
+end


### PR DESCRIPTION
## Proposed Changes
In cases where we could not access rails master key, e.g. dependabot PRs, it will error because STRIPE_CONFIG will be nil. This PR adds a safe guard in case its nil, meaning that local stripe testing will be skipped.

## Type of Change
- [ ] 🚨 *Breaking change* (fix or feature that would cause existing functionality to change)
- [ ] ✨ *New feature* (non-breaking change that adds functionality)
- [ ] 🐛 *Bug fix* (non-breaking change that fixes an issue)
- [ ] 🎨 *User interface change* (change to user interface; provide screenshots)
- [ ] ♻️ *Refactoring* (internal change to codebase, without changing functionality)
- [ ] 🚦 *Test update* (change that adds or modifies tests)
- [ ] 📦 *Dependency update* (change that updates a dependency)
- [ ] 🔧 *Internal* (change that affects developers or continuous integration)


## Checklist

- [ ] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [ ] I have added tests for my changes, if applicable.
- [ ] I have updated the project documentation, if applicable.
- [ ] I have verified that the CI tests have passed.
- [ ] I have reviewed the test coverage changes reported by Coveralls.