### PR TITLE
Make playable cover photo take explicit size

### DIFF
--- a/app/components/admin/track_component.html.erb
+++ b/app/components/admin/track_component.html.erb
@@ -1,6 +1,6 @@
-<%# the width of the card is width of image + 2 in tailwind %>
 <div id="<%= dom_id track %>" class="flex flex-col justify-start items-stretch bg-secondary-bg/40 dark:bg-secondary-bg/70 w-42 h-fit rounded p-1">
-  <%= render Tracks::PlayableCoverPhoto.new(track:, size: 40) %>
+  <%# the width of the image in rem is (taiwind_size - 2) / 4 %>
+  <%= render Tracks::PlayableCoverPhoto.new(track:, size: 10) %>
 
   <div class="flex flex-col justify-start items-start gap-0.5 px-3 text-[0.6rem] mt-2 w-full">
     <div class="flex justify-start items-stretch text-xs overflow-x-auto whitespace-nowrap w-full max-w-full">

--- a/app/components/tracks/playable_cover_photo.html.erb
+++ b/app/components/tracks/playable_cover_photo.html.erb
@@ -1,4 +1,4 @@
-<div class=<%= "relative w-full h-full #{image_size}" %>
+<div class=<%= "relative w-full h-full" %>
   data-controller="playable-cover-photo" data-playable-cover-photo-target="container"
   data-playable-cover-photo-audio-outlet="#audio-controller"
   data-playable-cover-photo-audio-player-outlet="#audio-player-controller"

--- a/app/components/tracks/playable_cover_photo.html.erb
+++ b/app/components/tracks/playable_cover_photo.html.erb
@@ -1,4 +1,5 @@
-<div class=<%= "relative w-full h-full" %>
+<div class="relative"
+  style="<%= "#{image_size}" %>"
   data-controller="playable-cover-photo" data-playable-cover-photo-target="container"
   data-playable-cover-photo-audio-outlet="#audio-controller"
   data-playable-cover-photo-audio-player-outlet="#audio-player-controller"
@@ -6,18 +7,18 @@
 
   <% cover_photo = capture do %>
     <% if track.cover_photo.attached? %>
-      <%= image_tag url_for(track.cover_photo), class: "cover-photo object-cover rounded #{image_size}" %>
+      <%= image_tag url_for(track.cover_photo), class: "cover-photo object-cover rounded w-full h-full" %>
     <% else %>
-      <div class="<%= "flex justify-center items-center bg-secondary-bg rounded #{image_size}" %>">
+      <%= content_tag :div, class: "flex justify-center items-center bg-secondary-bg rounded w-full h-full" do %>
         <%= icon "photo-scan", class: "cover-photo w-1/4 h-1/4" %>
-      </div>
+      <% end %>
     <% end %>
   <% end %>
 
   <% if controller.controller_name == "tracks" && controller.action_name == "show" %>
     <%= cover_photo %>
   <% else %>
-    <%= link_to track_path(id: track.slug_param) do %>
+    <%= link_to track_path(id: track.slug_param), class: "w-fit h-fit" do %>
       <%= cover_photo %>
     <% end %>
   <% end %>

--- a/app/components/tracks/playable_cover_photo.rb
+++ b/app/components/tracks/playable_cover_photo.rb
@@ -13,7 +13,7 @@ module Tracks
     attr_reader :track
 
     def image_size
-      size = @size.to_s + @unit
+      size = ("%g" % @size) + @unit
       "width: #{size}; height: #{size}; min-width: #{size};
       min-height: #{size}; max-width: #{size}; max-height: #{size};"
     end

--- a/app/components/tracks/playable_cover_photo.rb
+++ b/app/components/tracks/playable_cover_photo.rb
@@ -2,10 +2,10 @@
 
 module Tracks
   class PlayableCoverPhoto < ApplicationComponent
-    # size: num of rem
-    def initialize(track:, size:)
+    def initialize(track:, size:, unit: "rem")
       @track = track
       @size = size.to_f
+      @unit = unit
     end
 
     private
@@ -13,8 +13,9 @@ module Tracks
     attr_reader :track
 
     def image_size
-      "width: #{@size}rem; height: #{@size}rem; min-width: #{@size}rem; min-height:
-        #{@size}rem; max-width: #{@size}rem; max-height: #{@size}rem;"
+      size = @size.to_s + @unit
+      "width: #{size}; height: #{size}; min-width: #{size};
+      min-height: #{size}; max-width: #{size}; max-height: #{size};"
     end
   end
 end

--- a/app/components/tracks/playable_cover_photo.rb
+++ b/app/components/tracks/playable_cover_photo.rb
@@ -5,7 +5,7 @@ module Tracks
     # size: num of rem
     def initialize(track:, size:)
       @track = track
-      @size = size
+      @size = size.to_i
     end
 
     private
@@ -13,7 +13,8 @@ module Tracks
     attr_reader :track
 
     def image_size
-      "w-[#{@size}rem] h-[#{@size}rem] min-w-[#{@size}rem] min-h-[#{@size}rem] max-w-[#{@size}rem] max-h-[#{@size}rem]"
+      "width: #{@size}rem; height: #{@size}rem; min-width: #{@size}rem; min-height:
+        #{@size}rem; max-width: #{@size}rem; max-height: #{@size}rem;"
     end
   end
 end

--- a/app/components/tracks/playable_cover_photo.rb
+++ b/app/components/tracks/playable_cover_photo.rb
@@ -2,6 +2,7 @@
 
 module Tracks
   class PlayableCoverPhoto < ApplicationComponent
+    # size: num of rem
     def initialize(track:, size:)
       @track = track
       @size = size
@@ -12,7 +13,7 @@ module Tracks
     attr_reader :track
 
     def image_size
-      "w-#{@size} h-#{@size} min-w-#{@size} min-h-#{@size} max-w-#{@size} max-h-#{@size}"
+      "w-[#{@size}rem] h-[#{@size}rem] min-w-[#{@size}rem] min-h-[#{@size}rem] max-w-[#{@size}rem] max-h-[#{@size}rem]"
     end
   end
 end

--- a/app/components/tracks/playable_cover_photo.rb
+++ b/app/components/tracks/playable_cover_photo.rb
@@ -5,7 +5,7 @@ module Tracks
     # size: num of rem
     def initialize(track:, size:)
       @track = track
-      @size = size.to_i
+      @size = size.to_f
     end
 
     private

--- a/app/views/tracks/_rec_card.html.erb
+++ b/app/views/tracks/_rec_card.html.erb
@@ -2,7 +2,6 @@
 <% c_size = 34 %>
 <% image_size = c_size - 2 %>
 
-<%# TODO refactor playable cover photo to take in rem as unit for size %>
 <%= content_tag :div, class: "flex flex-col justify-start items-stretch gap-2 bg-secondary-bg/90 hover:bg-hover p-#{p} rounded w-#{c_size} max-w-#{c_size}" do %>
   <div class=<%= "w-#{image_size} h-#{image_size} max-w-#{image_size} max-h-#{image_size} aspect-square" %> >
     <%= render Tracks::PlayableCoverPhoto.new(track:, size: image_size / 4) %>

--- a/app/views/tracks/_rec_card.html.erb
+++ b/app/views/tracks/_rec_card.html.erb
@@ -1,11 +1,11 @@
-<% size = 30 %>
 <% p = 2 %>
-<% c_size = size + (p * 2) %>
+<% c_size = 34 %>
+<% image_size = c_size - 2 %>
 
 <%# TODO refactor playable cover photo to take in rem as unit for size %>
 <%= content_tag :div, class: "flex flex-col justify-start items-stretch gap-2 bg-secondary-bg/90 hover:bg-hover p-#{p} rounded w-#{c_size} max-w-#{c_size}" do %>
-  <div class=<%= "w-#{size} h-#{size} max-w-#{size} max-h-#{size} aspect-square" %> >
-    <%= render Tracks::PlayableCoverPhoto.new(track:, size:) %>
+  <div class=<%= "w-#{image_size} h-#{image_size} max-w-#{image_size} max-h-#{image_size} aspect-square" %> >
+    <%= render Tracks::PlayableCoverPhoto.new(track:, size: image_size / 4) %>
   </div>
 
   <div class="w-30 overflow-hidden">

--- a/app/views/tracks/show.html.erb
+++ b/app/views/tracks/show.html.erb
@@ -3,7 +3,7 @@
 <div class="flex flex-col justify-center items-center gap-12 w-full" data-controller="license-selection"
   data-license-selection-track-preview-modal-url-value="<%= track_purchase_modal_url(@track) %>">
   <section class="w-full grid grid-cols-[auto_1fr] gap-x-8 max-sm:grid-cols-1 max-sm:grid-rows-[auto_auto_auto] max-sm:justify-items-center max-sm:gap-y-8">
-    <div class="row-span-2 max-sm:row-span-1 max-sm:order-2 min-w-50 min-h-50 w-50 h-50">
+    <div class="row-span-2 max-sm:row-span-1 max-sm:order-2">
       <%= render Tracks::PlayableCoverPhoto.new(track: @track, size: 50) %>
     </div>
 

--- a/app/views/tracks/show.html.erb
+++ b/app/views/tracks/show.html.erb
@@ -4,7 +4,7 @@
   data-license-selection-track-preview-modal-url-value="<%= track_purchase_modal_url(@track) %>">
   <section class="w-full grid grid-cols-[auto_1fr] gap-x-8 max-sm:grid-cols-1 max-sm:grid-rows-[auto_auto_auto] max-sm:justify-items-center max-sm:gap-y-8">
     <div class="row-span-2 max-sm:row-span-1 max-sm:order-2">
-      <%= render Tracks::PlayableCoverPhoto.new(track: @track, size: 50) %>
+      <%= render Tracks::PlayableCoverPhoto.new(track: @track, size: 12.5) %>
     </div>
 
     <div class="flex-1 self-start max-sm:order-1 max-sm:self-auto max-sm:h-auto max-sm:text-center">

--- a/spec/components/tracks/playable_cover_photo_spec.rb
+++ b/spec/components/tracks/playable_cover_photo_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Tracks::PlayableCoverPhoto, type: :component do
     rendered = render_inline(described_class.new(track:, size: 6))
 
     expect(rendered).to have_css("img.cover-photo", count: 1)
-    expect(rendered).to have_css("[class*='w-[6rem]'][class*='h-[6rem]']", count: 1)
+    expect(rendered).to have_css("[style*='width: 6rem;'][style*='height: 6rem;']", count: 1)
   end
 
   it "renders an icon if cover photo is not attached" do
@@ -17,10 +17,17 @@ RSpec.describe Tracks::PlayableCoverPhoto, type: :component do
     rendered = render_inline(described_class.new(track:, size: 8))
 
     expect(rendered).to have_css("svg.cover-photo", count: 1)
-    expect(rendered).to have_css("[class*='w-[8rem]'][class*='h-[8rem]']", count: 1)
+    expect(rendered).to have_css("[style*='width: 8rem;'][style*='height: 8rem;']", count: 1)
   end
 
-  it "renders a play button" do
+  it "allows dynamic unit" do
+    rendered = render_inline(described_class.new(track:, size: 6, unit: "px"))
+
+    expect(rendered).to have_css("img.cover-photo", count: 1)
+    expect(rendered).to have_css("[style*='width: 6px;'][style*='height: 6px;']", count: 1)
+  end
+
+  it "renders play buttons" do
     rendered = render_inline(described_class.new(track:, size: 8))
 
     expect(rendered).to have_css("svg", count: 2)

--- a/spec/components/tracks/playable_cover_photo_spec.rb
+++ b/spec/components/tracks/playable_cover_photo_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Tracks::PlayableCoverPhoto, type: :component do
     rendered = render_inline(described_class.new(track:, size: 6))
 
     expect(rendered).to have_css("img.cover-photo", count: 1)
-    expect(rendered).to have_css("div.w-6.h-6.aspect-square", count: 1)
+    expect(rendered).to have_css("[class*='w-[6rem]'][class*='h-[6rem]']", count: 1)
   end
 
   it "renders an icon if cover photo is not attached" do
@@ -17,12 +17,12 @@ RSpec.describe Tracks::PlayableCoverPhoto, type: :component do
     rendered = render_inline(described_class.new(track:, size: 8))
 
     expect(rendered).to have_css("svg.cover-photo", count: 1)
-    expect(rendered).to have_css("div.w-8.h-8.aspect-square", count: 1)
+    expect(rendered).to have_css("[class*='w-[8rem]'][class*='h-[8rem]']", count: 1)
   end
 
   it "renders a play button" do
     rendered = render_inline(described_class.new(track:, size: 8))
 
-    expect(rendered).to have_css("svg.play-btn", count: 1)
+    expect(rendered).to have_css("svg", count: 2)
   end
 end


### PR DESCRIPTION
## Proposed Changes
Tailwind can't do dynamic rendering for components, so using rem or other units makes dynamic sizing the only way possible

## Type of Change
- [ ] 🚨 *Breaking change* (fix or feature that would cause existing functionality to change)
- [ ] ✨ *New feature* (non-breaking change that adds functionality)
- [x] 🐛 *Bug fix* (non-breaking change that fixes an issue)
- [ ] 🎨 *User interface change* (change to user interface; provide screenshots)
- [ ] ♻️ *Refactoring* (internal change to codebase, without changing functionality)
- [ ] 🚦 *Test update* (change that adds or modifies tests)
- [ ] 📦 *Dependency update* (change that updates a dependency)
- [x] 🔧 *Internal* (change that affects developers or continuous integration)


## Checklist

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [ ] I have added tests for my changes, if applicable.
- [ ] I have updated the project documentation, if applicable.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.