### PR TITLE
Add playable cover photo tracks to audio queue

### DIFF
--- a/app/components/admin/track_component.html.erb
+++ b/app/components/admin/track_component.html.erb
@@ -1,6 +1,6 @@
 <div id="<%= dom_id track %>" class="flex flex-col justify-start items-stretch bg-secondary-bg/40 dark:bg-secondary-bg/70 w-42 h-fit rounded p-1">
   <%# the width of the image in rem is (taiwind_size - 2) / 4 %>
-  <%= render Tracks::PlayableCoverPhoto.new(track:, size: 10) %>
+  <%= render Tracks::PlayableCoverPhoto.new(track:, queue_scope: "admin:tracks:index", size: 10) %>
 
   <div class="flex flex-col justify-start items-start gap-0.5 px-3 text-[0.6rem] mt-2 w-full">
     <div class="flex justify-start items-stretch text-xs overflow-x-auto whitespace-nowrap w-full max-w-full">

--- a/app/components/tracks/playable_cover_photo.html.erb
+++ b/app/components/tracks/playable_cover_photo.html.erb
@@ -1,16 +1,13 @@
-<div class="relative"
+<div
+  class="relative"
   style="<%= "#{image_size}" %>"
-  data-controller="playable-cover-photo" data-playable-cover-photo-target="container"
+  data-controller="playable-cover-photo"
+  data-playable-cover-photo-target="container"
   data-playable-cover-photo-audio-outlet="#audio-controller"
   data-playable-cover-photo-audio-player-outlet="#audio-player-controller"
+  data-playable-cover-photo-audio-queue-outlet="#audio-queue-controller"
   data-playable-cover-photo-track-id-value="<%= track.id %>"
-  data-track-id="<%= track.id %>"
-  data-track-title="<%= track.title %>"
-  data-track-image-url="<%= track.cover_photo.attached? ? track.cover_photo.url : "" %>"
-  data-track-metadata="<%= "#{track.bpm} • #{track.key} • #{track.genre}" %>"
-  data-queue-scope="<%= queue_scope %>"
 >
-
   <% cover_photo = capture do %>
     <% if track.cover_photo.attached? %>
       <%= image_tag url_for(track.cover_photo), class: "cover-photo object-cover rounded w-full h-full" %>
@@ -29,8 +26,15 @@
     <% end %>
   <% end %>
 
-  <div class="absolute bottom-2 right-2 bg-background rounded-full p-2 hover:bg-hover cursor-pointer select-none"
-    data-action="click->playable-cover-photo#togglePlay">
+  <div
+    class="absolute bottom-2 right-2 bg-background rounded-full p-2 hover:bg-hover cursor-pointer select-none"
+    data-action="click->playable-cover-photo#togglePlay"
+    data-track-id="<%= track.id %>"
+    data-track-title="<%= track.title %>"
+    data-track-image-url="<%= track.cover_photo.attached? ? track.cover_photo.url : "" %>"
+    data-track-metadata="<%= "#{track.bpm} • #{track.key} • #{track.genre}" %>"
+    data-queue-scope="<%= queue_scope %>"
+  >
     <%= icon "player-play", variant: "filled", class: "w-5 h-5", data: {
       playable_cover_photo_target: "play",
       action: "click->playable-cover-photo#pause"

--- a/app/components/tracks/playable_cover_photo.html.erb
+++ b/app/components/tracks/playable_cover_photo.html.erb
@@ -3,7 +3,13 @@
   data-controller="playable-cover-photo" data-playable-cover-photo-target="container"
   data-playable-cover-photo-audio-outlet="#audio-controller"
   data-playable-cover-photo-audio-player-outlet="#audio-player-controller"
-  data-playable-cover-photo-track-id-value="<%= track.id %>">
+  data-playable-cover-photo-track-id-value="<%= track.id %>"
+  data-track-id="<%= track.id %>"
+  data-track-title="<%= track.title %>"
+  data-track-image-url="<%= track.cover_photo.attached? ? track.cover_photo.url : "" %>"
+  data-track-metadata="<%= "#{track.bpm} • #{track.key} • #{track.genre}" %>"
+  data-queue-scope="<%= queue_scope %>"
+>
 
   <% cover_photo = capture do %>
     <% if track.cover_photo.attached? %>

--- a/app/components/tracks/playable_cover_photo.rb
+++ b/app/components/tracks/playable_cover_photo.rb
@@ -2,15 +2,16 @@
 
 module Tracks
   class PlayableCoverPhoto < ApplicationComponent
-    def initialize(track:, size:, unit: "rem")
+    def initialize(track:, queue_scope:, size:, unit: "rem")
       @track = track
+      @queue_scope = queue_scope
       @size = size.to_f
       @unit = unit
     end
 
     private
 
-    attr_reader :track
+    attr_reader :track, :queue_scope
 
     def image_size
       size = ("%g" % @size) + @unit

--- a/app/components/tracks/playable_cover_photo.rb
+++ b/app/components/tracks/playable_cover_photo.rb
@@ -2,7 +2,7 @@
 
 module Tracks
   class PlayableCoverPhoto < ApplicationComponent
-    def initialize(track:, queue_scope: "playable-cover-photo", size:, unit: "rem")
+    def initialize(track:, queue_scope:, size:, unit: "rem")
       @track = track
       @queue_scope = queue_scope
       @size = size.to_f

--- a/app/components/tracks/playable_cover_photo.rb
+++ b/app/components/tracks/playable_cover_photo.rb
@@ -2,7 +2,7 @@
 
 module Tracks
   class PlayableCoverPhoto < ApplicationComponent
-    def initialize(track:, queue_scope:, size:, unit: "rem")
+    def initialize(track:, queue_scope: "playable-cover-photo", size:, unit: "rem")
       @track = track
       @queue_scope = queue_scope
       @size = size.to_f

--- a/app/javascript/controllers/playable_cover_photo_controller.js
+++ b/app/javascript/controllers/playable_cover_photo_controller.js
@@ -4,7 +4,7 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static values = { trackId: Number };
   static targets = ["container", "play", "pause"];
-  static outlets = ["audio", "audio-player"];
+  static outlets = ["audio", "audio-player", "audio-queue"];
 
   connect() {
     document.addEventListener("playable-cover-photo:icon-toggle", (e) => {
@@ -17,13 +17,16 @@ export default class extends Controller {
     })
   }
 
-  togglePlay() {
-    this.audioPlayerOutlet.isPlaying() ? this.pause() : this.play();
+  togglePlay(e) {
+    this.audioPlayerOutlet.isPlaying() ? this.pause() : this.play(e);
   }
 
-  play() {
+  play(e) {
     this.audioOutlet.playAudio(this.trackIdValue);
     this.setIcon(true);
+
+    const queueScope = e.currentTarget.dataset.queueScope;
+    this.audioQueueOutlet.updateQueue(queueScope);
   }
 
   pause() {

--- a/app/views/audio/_queue.html.erb
+++ b/app/views/audio/_queue.html.erb
@@ -1,4 +1,4 @@
-<div id="audio-queue" class="hidden rounded bg-secondary-bg border-1 border-background py-2 px-4 max-sm:px-2 text-xs"
+<div id="audio-queue" class="hidden rounded bg-secondary-bg border-1 border-background py-2 px-4 max-sm:px-2 text-xs hide-scrollbar"
   data-audio-player-target="queueContainer">
   <div class="flex justify-between items-center">
     <div class="text-md font-bold mb-2"><%= t("audio.queue.title") %></div>

--- a/app/views/tracks/_rec_card.html.erb
+++ b/app/views/tracks/_rec_card.html.erb
@@ -1,10 +1,8 @@
-<% p = 2 %>
-<% c_size = 34 %>
-<% image_size = c_size - 2 %>
+<% image_size = c_size - p %>
 
 <%= content_tag :div, class: "flex flex-col justify-start items-stretch gap-2 bg-secondary-bg/90 hover:bg-hover p-#{p} rounded w-#{c_size} max-w-#{c_size}" do %>
   <div class=<%= "w-#{image_size} h-#{image_size} max-w-#{image_size} max-h-#{image_size} aspect-square" %> >
-    <%= render Tracks::PlayableCoverPhoto.new(track:, queue_scope: size: image_size / 4) %>
+    <%= render Tracks::PlayableCoverPhoto.new(track:, queue_scope:, size: image_size / 4) %>
   </div>
 
   <div class="w-30 overflow-hidden">

--- a/app/views/tracks/_rec_card.html.erb
+++ b/app/views/tracks/_rec_card.html.erb
@@ -4,7 +4,7 @@
 
 <%= content_tag :div, class: "flex flex-col justify-start items-stretch gap-2 bg-secondary-bg/90 hover:bg-hover p-#{p} rounded w-#{c_size} max-w-#{c_size}" do %>
   <div class=<%= "w-#{image_size} h-#{image_size} max-w-#{image_size} max-h-#{image_size} aspect-square" %> >
-    <%= render Tracks::PlayableCoverPhoto.new(track:, size: image_size / 4) %>
+    <%= render Tracks::PlayableCoverPhoto.new(track:, queue_scope: size: image_size / 4) %>
   </div>
 
   <div class="w-30 overflow-hidden">

--- a/app/views/tracks/_recommendation.html.erb
+++ b/app/views/tracks/_recommendation.html.erb
@@ -14,7 +14,7 @@
 
   <div class="flex justify-start items-stretch gap-4 overflow-x-auto hide-scrollbar" data-button-scroll-target="container">
     <% tracks.each do |track| %>
-      <%= render partial: "tracks/rec_card", locals: { track: } %>
+      <%= render partial: "tracks/rec_card", locals: { track:, queue_scope: "pages:home:rec_#{rec}" } %>
     <% end %>
   </div>
 </div>

--- a/app/views/tracks/_recommendation.html.erb
+++ b/app/views/tracks/_recommendation.html.erb
@@ -14,7 +14,7 @@
 
   <div class="flex justify-start items-stretch gap-4 overflow-x-auto hide-scrollbar" data-button-scroll-target="container">
     <% tracks.each do |track| %>
-      <%= render partial: "tracks/rec_card", locals: { track:, queue_scope: "pages:home:rec_#{rec}" } %>
+      <%= render partial: "tracks/rec_card", locals: { track:, queue_scope: "pages:home:rec_#{rec}", p: 2, c_size: 34 } %>
     <% end %>
   </div>
 </div>

--- a/app/views/tracks/show.html.erb
+++ b/app/views/tracks/show.html.erb
@@ -1,10 +1,11 @@
 <% content_for :title, @track.title %>
 
+<% queue_scope = "tracks:show" %>
 <div class="flex flex-col justify-center items-center gap-12 w-full" data-controller="license-selection"
   data-license-selection-track-preview-modal-url-value="<%= track_purchase_modal_url(@track) %>">
   <section class="w-full grid grid-cols-[auto_1fr] gap-x-8 max-sm:grid-cols-1 max-sm:grid-rows-[auto_auto_auto] max-sm:justify-items-center max-sm:gap-y-8">
     <div class="row-span-2 max-sm:row-span-1 max-sm:order-2">
-      <%= render Tracks::PlayableCoverPhoto.new(track: @track, size: 12.5) %>
+      <%= render Tracks::PlayableCoverPhoto.new(track: @track, queue_scope:, size: 12.5) %>
     </div>
 
     <div class="flex-1 self-start max-sm:order-1 max-sm:self-auto max-sm:h-auto max-sm:text-center">
@@ -81,7 +82,7 @@
     <%= render Tracks::ListComponent.new(
       tracks: @similar_tracks,
       current_user:,
-      queue_scope: "tracks:show",
+      queue_scope:,
       options: { render_message_if_empty: false }
     ) %>
   </section>

--- a/spec/components/tracks/playable_cover_photo_spec.rb
+++ b/spec/components/tracks/playable_cover_photo_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Tracks::PlayableCoverPhoto, type: :component do
   let(:track) { create(:track) }
 
   it "renders the cover photo if one is attached" do
-    rendered = render_inline(described_class.new(track:, size: 6))
+    rendered = render_inline(described_class.new(track:, queue_scope: "spec", size: 6))
 
     expect(rendered).to have_css("img.cover-photo", count: 1)
     expect(rendered).to have_css("[style*='width: 6rem;'][style*='height: 6rem;']", count: 1)
@@ -14,21 +14,21 @@ RSpec.describe Tracks::PlayableCoverPhoto, type: :component do
 
   it "renders an icon if cover photo is not attached" do
     track.cover_photo.purge
-    rendered = render_inline(described_class.new(track:, size: 8))
+    rendered = render_inline(described_class.new(track:, queue_scope: "spec", size: 8))
 
     expect(rendered).to have_css("svg.cover-photo", count: 1)
     expect(rendered).to have_css("[style*='width: 8rem;'][style*='height: 8rem;']", count: 1)
   end
 
   it "allows dynamic unit" do
-    rendered = render_inline(described_class.new(track:, size: 6, unit: "px"))
+    rendered = render_inline(described_class.new(track:, queue_scope: "spec", size: 6, unit: "px"))
 
     expect(rendered).to have_css("img.cover-photo", count: 1)
     expect(rendered).to have_css("[style*='width: 6px;'][style*='height: 6px;']", count: 1)
   end
 
   it "renders play buttons" do
-    rendered = render_inline(described_class.new(track:, size: 8))
+    rendered = render_inline(described_class.new(track:, queue_scope: "spec", size: 8))
 
     expect(rendered).to have_css("svg", count: 2)
   end


### PR DESCRIPTION
## Proposed Changes
Include playable cover photo tracks in audio queue

## Type of Change
- [ ] 🚨 *Breaking change* (fix or feature that would cause existing functionality to change)
- [x] ✨ *New feature* (non-breaking change that adds functionality)
- [ ] 🐛 *Bug fix* (non-breaking change that fixes an issue)
- [ ] 🎨 *User interface change* (change to user interface; provide screenshots)
- [ ] ♻️ *Refactoring* (internal change to codebase, without changing functionality)
- [ ] 🚦 *Test update* (change that adds or modifies tests)
- [ ] 📦 *Dependency update* (change that updates a dependency)
- [ ] 🔧 *Internal* (change that affects developers or continuous integration)


## Checklist

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
- [ ] I have updated the project documentation, if applicable.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.