### PR TITLE
Add endpoint to reorder a sing recommendation

### DIFF
--- a/app/controllers/admin/recommendations_controller.rb
+++ b/app/controllers/admin/recommendations_controller.rb
@@ -51,7 +51,7 @@ module Admin
       redirect_to admin_recommendations_path, status: :see_other, notice: t("admin.recommendations.destroy.success")
     end
 
-    def reorder
+    def reorder_all
       ordering = params.require(:track_recommendation).permit(ordering: [])[:ordering].presence || []
       ordering = ordering.reject(&:blank?)
 
@@ -69,6 +69,13 @@ module Admin
       ordering.each_with_index do |id, index|
         TrackRecommendation.find(id).update(display_order_position: index)
       end
+    end
+
+    def reorder_one
+      id = params[:id]
+      index = params[:new_idex]
+
+      TrackRecommendation.find(id).update(display_order_position: index)
     end
 
     private

--- a/app/controllers/admin/recommendations_controller.rb
+++ b/app/controllers/admin/recommendations_controller.rb
@@ -72,10 +72,10 @@ module Admin
     end
 
     def reorder_one
-      id = params[:id]
-      index = params[:new_idex]
+      id = params[:id].to_i
+      position = params[:position].to_i
 
-      TrackRecommendation.find(id).update(display_order_position: index)
+      TrackRecommendation.find(id).update(display_order_position: position)
     end
 
     private

--- a/app/controllers/admin/recommendations_controller.rb
+++ b/app/controllers/admin/recommendations_controller.rb
@@ -72,8 +72,8 @@ module Admin
     end
 
     def reorder_one
-      id = params[:id].to_i
-      position = params[:position].to_i
+      id = params[:id]
+      position = params[:position]
 
       TrackRecommendation.find(id).update(display_order_position: position)
     end

--- a/app/javascript/controllers/recommendations_drag_controller.js
+++ b/app/javascript/controllers/recommendations_drag_controller.js
@@ -12,18 +12,17 @@ export default class extends DragAndSortController {
       animation: 500,
       easing: "cubic-beizer(0.42, 0, 1, 1)",
       dataIdAttr: "data-recommendation-id",
-      onUpdate: () => {
-        fetch(this.reorderApiUrlValue, {
+      onUpdate: (e) => {
+        const id = parseInt(e.item.dataset.recommendationId);
+        const position = parseInt(e.newIndex);
+        const url = this.reorderApiUrlValue.replace(":id", id).replace(":position", position);
+
+        fetch(url, {
           method: "PUT",
           headers: {
             "X-CSRF-Token": document.querySelector("[name='csrf-token']").content,
             "Content-Type": "application/json",
           },
-          body: JSON.stringify({
-            track_recommendation: {
-              ordering: this.sortable.toArray().map((id) => parseInt(id))
-            }
-          }),
         })
         .then((res) => {
           if (!res.ok) {

--- a/app/views/admin/recommendations/index.html.erb
+++ b/app/views/admin/recommendations/index.html.erb
@@ -20,7 +20,7 @@
       class="flex flex-col justify-start items-stretch gap-2"
       data-controller="recommendations-drag"
       data-recommendations-drag-target="list"
-      data-recommendations-drag-reorder-api-url-value="<%= reorder_admin_recommendations_url %>"
+      data-recommendations-drag-reorder-api-url-value="<%= reorder_admin_recommendation_url(id: ":id", position: ":position") %>"
     >
       <% @recommendations.each do |recommendation| %>
         <%= render Admin::RecommendationComponent.new(recommendation:) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,7 +69,11 @@ Rails.application.routes.draw do
 
     resources :recommendations, except: [ :show ] do
       collection do
-        put :reorder
+        put :reorder, to: "reorder_all", as: "reorder"
+      end
+
+      member do
+        put "reorder/:new_index", to: "reorder_one", as: "reorder"
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,7 +73,7 @@ Rails.application.routes.draw do
       end
 
       member do
-        put "reorder/:new_index", to: "reorder_one", as: "reorder"
+        put "reorder/:position", to: "reorder_one", as: "reorder"
       end
     end
   end

--- a/spec/requests/admin/recommendations_spec.rb
+++ b/spec/requests/admin/recommendations_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe Admin::LicensesController, type: :request, admin: true do
     let(:r3) { create(:track_recommendation, group: "C") }
 
     it "should reorder recommendation to the correct index" do
-      put reorder_admin_recommendation_url(r3, new_index: 0)
+      put reorder_admin_recommendation_url(r3, position: 0)
 
       actual = TrackRecommendation.rank(:display_order)
       expected = [ r3, r1, r2 ]

--- a/spec/requests/admin/recommendations_spec.rb
+++ b/spec/requests/admin/recommendations_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe Admin::LicensesController, type: :request, admin: true do
     end
   end
 
-  describe "#reorder" do
+  describe "#reorder_all" do
     let(:r1) { create(:track_recommendation, group: "A") }
     let(:r2) { create(:track_recommendation, group: "B") }
     let(:r3) { create(:track_recommendation, group: "C") }
@@ -185,6 +185,22 @@ RSpec.describe Admin::LicensesController, type: :request, admin: true do
       expected = [ r1, r2, r3 ]
 
       expect(response).to have_http_status(:bad_request)
+      expect(actual).to eq(expected)
+    end
+  end
+
+  describe "#reorder_one" do
+    let(:r1) { create(:track_recommendation, group: "A") }
+    let(:r2) { create(:track_recommendation, group: "B") }
+    let(:r3) { create(:track_recommendation, group: "C") }
+
+    it "should reorder recommendation to the correct index" do
+      put reorder_admin_recommendation_url(r3, new_index: 0)
+
+      actual = TrackRecommendation.rank(:display_order)
+      expected = [ r3, r1, r2 ]
+
+      expect(response).to have_http_status(:no_content)
       expect(actual).to eq(expected)
     end
   end


### PR DESCRIPTION
## Proposed Changes
Just realized that we can also reorder a recommendation just with its index. The old way could lead to N+1.

## Type of Change
- [ ] 🚨 *Breaking change* (fix or feature that would cause existing functionality to change)
- [x] ✨ *New feature* (non-breaking change that adds functionality)
- [ ] 🐛 *Bug fix* (non-breaking change that fixes an issue)
- [ ] 🎨 *User interface change* (change to user interface; provide screenshots)
- [ ] ♻️ *Refactoring* (internal change to codebase, without changing functionality)
- [ ] 🚦 *Test update* (change that adds or modifies tests)
- [ ] 📦 *Dependency update* (change that updates a dependency)
- [ ] 🔧 *Internal* (change that affects developers or continuous integration)


## Checklist

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
- [ ] I have updated the project documentation, if applicable.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.